### PR TITLE
fix : cicd를 진행할때 이전 도커 관련 파일을 지우도록 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           script: |
             cd /home/ubuntu/starlet
             docker-compose down
+            docker system prune -a --volumes --force
             docker-compose pull
             docker-compose up -d
             docker image prune -f


### PR DESCRIPTION
## PR 요약
- 볼륨 용량 이슈로 인하여, 이전에 있던 캐시 파일들을 모두 지우고 새로운 이미지로만 빌드하도록 설정하였습니다.

