### PR TITLE
feat : diary 작성 기능 구현

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/api/DiaryApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/api/DiaryApi.java
@@ -1,0 +1,207 @@
+package com.example.starlet_be.domains.diary.api;
+
+import com.example.starlet_be.domains.diary.dto.reqdto.DiaryCreateReqDto;
+import com.example.starlet_be.domains.diary.dto.reqdto.DiaryUpdateReqDto;
+import com.example.starlet_be.domains.diary.dto.resdto.DiaryResDto;
+import com.example.starlet_be.domains.diary.dto.resdto.StarMonthlyResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Calendar (Diary) API", description = "감정 일기 생성/수정/조회 및 월별 별 조회 API")
+public interface DiaryApi {
+
+    @Operation(
+            summary = "감정 일기 생성",
+            description = """
+            사용자가 하루에 하나 감정 일기를 작성할 수 있습니다.
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "작성 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = DiaryResDto.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "date": "2025-09-09",
+                      "emotion": "HAPPINESS",
+                      "color": "YELLOW",
+                      "factors": ["FRIEND","WORK"],
+                      "content": "오늘은 소공 수업을 했는데, 너무너무 재미있었다!"
+                    }
+                """))),
+            @ApiResponse(responseCode = "400", description = "입력 누락/형식 오류",
+                    content = @Content(mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "필드 누락", value = """
+                        { "emotion": "감정은 필수 입력입니다." }
+                    """),
+                                    @ExampleObject(name = "내용 길이 오류", value = """
+                        { "content": "내용은 15자 이상 300자 이하로 입력해주세요." }
+                    """)
+                            })),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 401, "message": "토큰이 없거나 만료되었습니다." }
+                """))),
+            @ApiResponse(responseCode = "409", description = "동일 날짜 일기 중복",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 409, "message": "해당 날짜에 이미 감정 일기가 존재합니다." }
+                """)))
+    })
+    @PostMapping("/diary")
+    ResponseEntity<?> createDiary(
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody DiaryCreateReqDto req
+    );
+
+    /* ===================================== */
+
+    @Operation(
+            summary = "감정 일기 수정(내용만)",
+            description = "요청한 날짜의 일기 내용을 수정합니다. 존재하지 않으면 404를 반환합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = DiaryResDto.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "date": "2025-09-09",
+                      "emotion": "HAPPINESS",
+                      "color": "YELLOW",
+                      "factors": ["FRIEND","WORK"],
+                      "content": "사실은 수업 오기 너무너무 귀찮았다...흑흑"
+                    }
+                """))),
+            @ApiResponse(responseCode = "400", description = "입력 누락/형식 오류",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "content": "내용은 15자 이상 300자 이하로 입력해주세요." }
+                """))),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 401, "message": "토큰이 없거나 만료되었습니다." }
+                """))),
+            @ApiResponse(responseCode = "404", description = "해당 날짜 일기 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 404, "message": "해당 날짜의 일기를 찾을 수 없습니다. (2025-09-09)" }
+                """)))
+    })
+    @PatchMapping("/diary")
+    ResponseEntity<?> updateDiary(
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody DiaryUpdateReqDto req
+    );
+
+    /* ===================================== */
+
+    @Operation(
+            summary = "특정 날짜 감정 일기 조회",
+            description = "YYYY-MM-DD 형식의 날짜로 해당 날짜 일기를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = DiaryResDto.class),
+                            examples = @ExampleObject(value = """
+                    {
+                      "date": "2025-09-09",
+                      "emotion": "HAPPINESS",
+                      "color": "YELLOW",
+                      "factors": ["FRIEND","WORK"],
+                      "content": "오늘은 소공 수업을 했는데, 너무너무 재미있었다!"
+                    }
+                """))),
+            @ApiResponse(responseCode = "400", description = "날짜 형식 오류",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 400, "message": "date 파라미터 형식이 올바르지 않습니다." }
+                """))),
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 401, "message": "토큰이 없거나 만료되었습니다." }
+                """))),
+            @ApiResponse(responseCode = "404", description = "해당 날짜 일기 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 404, "message": "해당 날짜의 감정 일기를 찾을 수 없습니다." }
+                """)))
+    })
+    @GetMapping("/diary/{date}")
+    ResponseEntity<?> getDiary(
+            @AuthenticationPrincipal UserDetails principal,
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    );
+
+    /* ===================================== */
+
+    @Operation(
+            summary = "월별 별 목록 조회",
+            description = """
+            year, month 쿼리 파라미터로 해당 월의 별(하이라이트) 목록을 반환합니다.
+            예: GET /api/v1/calendar/star?year=2025&month=9
+            """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = StarMonthlyResDto.class),
+                            examples = @ExampleObject(value = """
+                    [
+                      { "date": "2025-09-03", "color": "ORANGE" },
+                      { "date": "2025-09-12", "color": "YELLOW" },
+                      { "date": "2025-09-21", "color": "BLUE" }
+                    ]
+                """))),
+            @ApiResponse(responseCode = "400", description = "파라미터 형식 오류",
+                    content = @Content(mediaType = "application/json",
+                            examples = {
+                                    @ExampleObject(name = "year 누락", value = """
+                        { "status": 400, "message": "year 파라미터는 필수입니다." }
+                    """),
+                                    @ExampleObject(name = "month 누락", value = """
+                        { "status" : 400, "message": "month 파라미터는 필수입니다." }
+                    """),
+                                    @ExampleObject(name = "year 형식 오류", value = """
+                        { "status" : 400, "message": "year 파라미터 형식이 올바르지 않습니다." }
+                    """),
+                                    @ExampleObject(name = "month 형식 오류", value = """
+                        { "status" : 400, "message": "month 파라미터 형식이 올바르지 않습니다." }
+                    """),
+                                    @ExampleObject(name = "month 범위 오류", value = """
+                        { "status": 400, "message": "month는 1~12 사이여야 합니다." }
+                    """)
+                            })),
+
+            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+                    { "status": 401, "message": "토큰이 없거나 만료되었습니다." }
+                """)))
+    })
+    @GetMapping("/star")
+    ResponseEntity<List<StarMonthlyResDto>> getMonthlyStars(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam int year,
+            @RequestParam int month
+    );
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/controller/DiaryController.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/controller/DiaryController.java
@@ -1,0 +1,89 @@
+package com.example.starlet_be.domains.diary.controller;
+
+import com.example.starlet_be.domains.diary.api.DiaryApi;
+import com.example.starlet_be.domains.diary.dto.reqdto.DiaryCreateReqDto;
+import com.example.starlet_be.domains.diary.dto.reqdto.DiaryUpdateReqDto;
+import com.example.starlet_be.domains.diary.dto.resdto.DiaryResDto;
+import com.example.starlet_be.domains.diary.dto.resdto.StarMonthlyResDto;
+import com.example.starlet_be.domains.diary.service.DiaryService;
+import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.domains.user.repository.UserRepository;
+import com.example.starlet_be.exception.CustomException;
+import com.example.starlet_be.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/calendar")
+@RequiredArgsConstructor
+public class DiaryController implements DiaryApi {
+
+    private final DiaryService diaryService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/diary")
+    public ResponseEntity<DiaryResDto> createDiary(
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody DiaryCreateReqDto req
+    ) {
+        Long userId = resolveUserId(principal);
+        DiaryResDto body = diaryService.create(userId, req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    @PatchMapping("/diary")
+    public ResponseEntity<DiaryResDto> updateDiary(
+            @AuthenticationPrincipal UserDetails principal,
+            @Valid @RequestBody DiaryUpdateReqDto req
+    ) {
+        Long userId = resolveUserId(principal);
+        DiaryResDto body = diaryService.update(userId, req);
+        return ResponseEntity.ok(body);
+    }
+
+    @GetMapping("/diary/{date}")
+    public ResponseEntity<DiaryResDto> getDiary(
+            @AuthenticationPrincipal UserDetails principal,
+            @PathVariable @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        Long userId = resolveUserId(principal);
+        DiaryResDto body = diaryService.getByDate(userId, date);
+        return ResponseEntity.ok(body);
+    }
+
+
+    @GetMapping("/star")
+    public ResponseEntity<List<StarMonthlyResDto>> getMonthlyStars(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        if(month < 1 || month > 12) {
+            throw new CustomException(ErrorCode.DIARY_INVALID_MONTH);
+        }
+
+        Long userId = resolveUserId(principal);
+        YearMonth ym = YearMonth.of(year, month);
+        List<StarMonthlyResDto> body = diaryService.getMonthlyStars(userId, ym);
+        return ResponseEntity.ok(body);
+    }
+
+    private Long resolveUserId(UserDetails principal) {
+        String email = principal.getUsername();
+        return userRepository.findByEmailAddress(email)
+                .map(User::getId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다: " + email));
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/reqdto/DiaryCreateReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/reqdto/DiaryCreateReqDto.java
@@ -1,0 +1,36 @@
+package com.example.starlet_be.domains.diary.dto.reqdto;
+
+import com.example.starlet_be.domains.diary.entity.Emotion;
+import com.example.starlet_be.domains.diary.entity.Factor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DiaryCreateReqDto {
+
+    @Schema(description = "감정", example = "HAPPINESS")
+    @NotNull(message = "감정은 필수 입력입니다.")
+    private Emotion emotion;
+
+    @Schema(description = "감정 요인 태그 목록", example = "[\"FRIEND\",\"WORK\"]")
+    @NotEmpty(message = "감정 요인은 최소 1개 이상 선택해야 합니다.")
+    private List<@NotNull Factor> factors;
+
+    @Schema(description = "내용(15~300자)", example = "오늘은 소공 수업을 했는데, 너무너무 재미있었다!")
+    @Size(min = 15, max = 300, message = "내용은 15자 이상 300자 이하로 입력해주세요.")
+    private String content;
+
+    @Schema(description = "일기 날짜(오늘)", example = "2025-09-09")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    @NotNull(message = "날짜는 필수 입력입니다.")
+    private LocalDate date;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/reqdto/DiaryUpdateReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/reqdto/DiaryUpdateReqDto.java
@@ -1,0 +1,27 @@
+package com.example.starlet_be.domains.diary.dto.reqdto;
+
+import com.example.starlet_be.domains.diary.entity.Emotion;
+import com.example.starlet_be.domains.diary.entity.Factor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class DiaryUpdateReqDto {
+
+    @Schema(description = "수정 대상 날짜", example = "2025-09-09")
+    @NotNull(message = "수정 대상 날짜는 필수입니다.")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate date;
+
+    @Schema(description = "내용(15~300자)", example = "사실은 수업 오기 너무너무 귀찮았다...흑흑")
+    @Size(min = 15, max = 300, message = "내용은 15자 이상 300자 이하로 입력해주세요.")
+    private String content;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/resdto/DiaryResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/resdto/DiaryResDto.java
@@ -1,0 +1,44 @@
+package com.example.starlet_be.domains.diary.dto.resdto;
+
+import com.example.starlet_be.domains.diary.entity.Color;
+import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.diary.entity.Emotion;
+import com.example.starlet_be.domains.diary.entity.Factor;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DiaryResDto {
+
+    @Schema(example = "2025-09-09")
+    private LocalDate date;
+
+    @Schema(example = "HAPPINESS")
+    private Emotion emotion;
+
+    @Schema(example = "YELLOW")
+    private Color color;
+
+    @Schema(example = "[\"FRIEND\",\"WORK\"]")
+    private List<Factor> factors;
+
+    @Schema(example = "오늘은 소공 수업을 했는데, 너무너무 재미있었다!")
+    private String content;
+
+    public static DiaryResDto of(Diary d) {
+        return DiaryResDto.builder()
+                .date(d.getCreateAt())
+                .emotion(d.getEmotion())
+                .color(d.getEmotion().getColor())
+                .factors(d.getFactors())
+                .content(d.getContent())
+                .build();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/resdto/StarMonthlyResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/dto/resdto/StarMonthlyResDto.java
@@ -1,0 +1,19 @@
+package com.example.starlet_be.domains.diary.dto.resdto;
+
+import com.example.starlet_be.domains.diary.entity.Color;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class StarMonthlyResDto {
+
+    @Schema(example = "2025-09-03")
+    private LocalDate date;
+
+    @Schema(example = "ORANGE")
+    private Color color;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/entity/Diary.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/entity/Diary.java
@@ -26,10 +26,14 @@ public class Diary {
     @Enumerated(EnumType.STRING)
     private Emotion emotion;
 
-    @Column(nullable = false)
+    @ElementCollection(fetch = FetchType.LAZY)
+    @CollectionTable(
+            name = "diary_factor",
+            joinColumns = @JoinColumn(name = "diary_id")
+    )
+    @Column(name = "factor", nullable = false, length = 20)
     @Enumerated(EnumType.STRING)
     private List<Factor> factors = new ArrayList<>();
-    // 필드에서 바로 리스트 할 필요 있을지도
 
     @Column
     private String content;
@@ -44,4 +48,12 @@ public class Diary {
         this.content = content;
         this.createAt = createAt;
     }
+
+    @Version
+    private Long version;
+
+    public void updateContent(String newContent) {
+        this.content = newContent;
+    }
+
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/repository/DiaryRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/repository/DiaryRepository.java
@@ -1,0 +1,22 @@
+package com.example.starlet_be.domains.diary.repository;
+
+import com.example.starlet_be.domains.diary.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    //1. 사용자/날짜의 일기 존재 여부
+    boolean existsByUser_IdAndCreateAt(Long userId, LocalDate date);
+
+    //2. 일기 조회
+    Optional<Diary> findByUser_IdAndCreateAt(Long userId, LocalDate date);
+
+    //3. 달력 안 별 조회
+    List<Diary> findAllByUser_IdAndCreateAtBetweenOrderByCreateAtAsc(
+            Long userId, LocalDate from, LocalDate to
+    );
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
@@ -1,0 +1,135 @@
+package com.example.starlet_be.domains.diary.service;
+
+import com.example.starlet_be.exception.CustomException;
+import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.diary.entity.Factor;
+import com.example.starlet_be.domains.diary.dto.reqdto.DiaryCreateReqDto;
+import com.example.starlet_be.domains.diary.dto.reqdto.DiaryUpdateReqDto;
+import com.example.starlet_be.domains.diary.repository.DiaryRepository;
+import com.example.starlet_be.domains.diary.dto.resdto.DiaryResDto;
+import com.example.starlet_be.domains.diary.dto.resdto.StarMonthlyResDto;
+import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.exception.ErrorCode;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 감정 일기(Diary) 서비스
+ * - 생성 / 수정 / 조회 / 월별 별 조회
+ * - 하루에 한 개의 일기만 작성 가능
+ * - +(계정 탈퇴 할 거면 existsById로 확인해야하니 체크할 것)
+ */
+@Service
+@RequiredArgsConstructor
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+    private final EntityManager em;
+
+    /**
+     * 새로운 감정 일기를 생성한다.
+     *
+     * date가 null이면 오늘 날짜로 기본 설정
+     * 동일 사용자/날짜의 일기가 이미 있으면 DiaryExceptions.AlreadyExists 예외 발생
+     *
+     * @param userId 작성자 ID
+     * @param req    생성 요청 DTO
+     * @return DiaryResDto 응답 DTO
+     *
+     */
+    @Transactional
+    public DiaryResDto create(Long userId, DiaryCreateReqDto req) {
+        LocalDate date = req.getDate();
+
+        if (diaryRepository.existsByUser_IdAndCreateAt(userId, date)) {
+            throw new CustomException(ErrorCode.DIARY_ALREADY_EXISTS);
+        }
+
+        User userRef = em.getReference(User.class, userId);
+
+        Diary diary = Diary.builder()
+                .user(userRef)
+                .emotion(req.getEmotion())
+                .factors(safeFactors(req.getFactors()))
+                .content(req.getContent())
+                .createAt(date)
+                .build();
+
+        diaryRepository.save(diary);
+
+        return DiaryResDto.of(diary);
+    }
+
+    /**
+     * 특정 날짜의 감정 일기를 수정한다.
+     * 수정 가능한 필드: content
+     *
+     * @param userId 사용자 ID
+     * @param req    수정 요청 DTO
+     * @return DiaryResDto 응답 DTO
+     * @throws CustomException ErrorCode.DIARY_NOT_FOUND 동일 사용자/날짜가 이미 존재할 경우
+     */
+    @Transactional
+    public DiaryResDto update(Long userId, DiaryUpdateReqDto req) {
+        LocalDate date = req.getDate();
+        Diary diary = diaryRepository.findByUser_IdAndCreateAt(userId, date)
+                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+
+        if (req.getContent() != null) {
+            diary.updateContent(req.getContent());
+        }
+
+        return DiaryResDto.of(diary);
+    }
+
+    /**
+     * 특정 날짜의 감정 일기를 조회한다.
+     *
+     * @param userId 사용자 ID
+     * @param date   조회할 날짜
+     * @return DiaryResDto 응답 DTO
+     * @throws CustomException ErrorCode.DIARY_NOT_FOUND 동일 사용자/날짜가 이미 존재할 경우
+     */
+    public DiaryResDto getByDate(Long userId, LocalDate date) {
+        Diary diary = diaryRepository.findByUser_IdAndCreateAt(userId, date)
+                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND));
+        return DiaryResDto.of(diary);
+    }
+
+    /**
+     * 특정 월의 별들을 조회한다.
+     *
+     * Diary 엔티티에서 emotion → color를 계산하여 반환
+     * 날짜 오름차순
+     *
+     * @param userId 사용자 ID
+     * @param ym     조회할 년/월
+     * @return StarMonthlyResDto 리스트
+     */
+    public List<StarMonthlyResDto> getMonthlyStars(Long userId, YearMonth ym) {
+        LocalDate from = ym.atDay(1);
+        LocalDate to = ym.atEndOfMonth();
+
+        return diaryRepository
+                .findAllByUser_IdAndCreateAtBetweenOrderByCreateAtAsc(userId, from, to)
+                .stream()
+                .map(d -> new StarMonthlyResDto(d.getCreateAt(), d.getEmotion().getColor()))
+                .toList();
+    }
+
+    /* ======== */
+
+    /**
+     * null 안전하게 factors 리스트 생성
+     */
+    private List<Factor> safeFactors(List<Factor> in) {
+        return (in != null) ? new ArrayList<>(in) : new ArrayList<>();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
@@ -124,11 +124,6 @@ public class DiaryService {
                 .toList();
     }
 
-    /* ======== */
-
-    /**
-     * null 안전하게 factors 리스트 생성
-     */
     private List<Factor> safeFactors(List<Factor> in) {
         return (in != null) ? new ArrayList<>(in) : new ArrayList<>();
     }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
@@ -26,8 +26,11 @@ public enum ErrorCode {
     DUPLICATE_INFO_CONFLICT(409, "이미 사용중인 정보가 있습니다. 이메일과 닉네임 중복검사를 시행하세요."),
     USER_CREATE_FAILED(500, "유저 생성에 실패하였습니다."),
 
-
-
+    // diary 관련
+    DIARY_ALREADY_EXISTS(409, "해당 날짜에는 이미 감정 일기가 존재합니다."),
+    DIARY_NOT_FOUND(404, "해당 날짜의 감정 일기를 찾을 수 없습니다."),
+    DIARY_INVALID_PARAM(400, "요청 값이 올바르지 않습니다."),
+    DIARY_INVALID_MONTH(400, "month는 1~12 사이여야 합니다."),
 
 
     // 기타 관련

--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/GlobalExceptionHandler.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/GlobalExceptionHandler.java
@@ -44,6 +44,29 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
     }
 
+    // @RequestParam 누락
+    @ExceptionHandler(org.springframework.web.bind.MissingServletRequestParameterException.class)
+    protected ResponseEntity<ErrorDto> handleMissingParam(
+            org.springframework.web.bind.MissingServletRequestParameterException ex) {
+        String msg = ex.getParameterName() + " 파라미터는 필수입니다.";
+        return ResponseEntity.badRequest().body(new ErrorDto(400, msg));
+    }
+
+    // 타입/형식 변환 실패
+    @ExceptionHandler(org.springframework.web.method.annotation.MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorDto> handleTypeMismatch(
+            org.springframework.web.method.annotation.MethodArgumentTypeMismatchException ex) {
+
+        Throwable cause = ex.getCause();
+        if (cause instanceof java.time.format.DateTimeParseException) {
+            return ResponseEntity.badRequest().body(new ErrorDto(400, "날짜 형식이 올바르지 않습니다. (yyyy-MM-dd)"));
+        }
+
+        String name = ex.getName(); // year, month 등 파라미터 이름
+        return ResponseEntity.badRequest().body(new ErrorDto(400, name + " 파라미터 형식이 올바르지 않습니다."));
+    }
+
+
     // 이미지와 같은 파일을 올릴때 사용할 예외들(현재 비활성화)
 
 //    // RequestPart에 대한 누락


### PR DESCRIPTION
## PR 요약
**Diary 작성 기능** 구현 완료

---

## 변경 내용
- diary entity 수정 :` CollectionTable`로 `factor` 관리

1. diary 작성
: 하루에 하나만 작성할 수 있도록 제한
2. diary 수정
: `content`만 수정할 수 있도록 제한
3. diary 상세 조회
4. **월별 별 조회 \*\*** 
: 현재 `emotion`을 기준으로 단순 색만 반환. 
추후에 일기 생성 후 별이 생성되면, 해당 별에 대한 정보를 반환하도록 수정 예정임

- 문서 업데이트
Calendar (Diary) API swagger 작성

---

## 관련 이슈
- 계정 탈퇴 추가로 인해, error 처리 추가 필요해 보임.
