### PR TITLE
ERD 참고하여 엔티티 연관관계 정의

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/connection/connection/Connection.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/connection/connection/Connection.java
@@ -1,0 +1,35 @@
+package com.example.starlet_be.domains.connection.connection;
+
+import com.example.starlet_be.domains.constellation.entity.Constellation;
+import com.example.starlet_be.domains.star.entity.Star;
+import com.example.starlet_be.domains.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Connection {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "constellation_id", nullable = false)
+    private Constellation constellation;
+
+    @ManyToOne
+    @JoinColumn(name = "start_star_id", nullable = false)
+    private Star start;
+
+    @ManyToOne
+    @JoinColumn(name = "end_star_id", nullable = false)
+    private Star end;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/entity/Constellation.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/entity/Constellation.java
@@ -1,0 +1,55 @@
+package com.example.starlet_be.domains.constellation.entity;
+
+import com.example.starlet_be.domains.connection.connection.Connection;
+import com.example.starlet_be.domains.star.entity.Star;
+import com.example.starlet_be.domains.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Constellation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDate createAt;
+
+    @Column
+    private boolean isRepresentative;
+
+    @Column(nullable = false)
+    private Double x;
+
+    @Column(nullable = false)
+    private Double y;
+
+    @OneToMany(mappedBy = "constellation", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Star> stars = new ArrayList<>();
+
+    @OneToMany(mappedBy = "constellation", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Connection> connections = new ArrayList<>();
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/entity/Diary.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/entity/Diary.java
@@ -1,5 +1,6 @@
 package com.example.starlet_be.domains.diary.entity;
 
+import com.example.starlet_be.domains.star.entity.Star;
 import com.example.starlet_be.domains.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -40,6 +41,9 @@ public class Diary {
 
     @Column(nullable = false)
     private LocalDate createAt;
+
+    @OneToOne(mappedBy = "diary", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Star star;
 
     @Builder public Diary(User user, Emotion emotion, List<Factor> factors, String content, LocalDate createAt) {
         this.user = user;

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/entity/Email.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/entity/Email.java
@@ -28,7 +28,7 @@ public class Email {
     @Column
     private String address;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true)
     @JoinColumn(name = "verify_id", nullable = false)
     private Verify verify;
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
@@ -53,7 +53,6 @@ public class Star {
     @JoinColumn(name = "user_id")
     private User user;
 
-    // Star.java에 추가 (이 방법은 복잡성이 증가하여 특별한 이유가 없다면 추천하지 않습니다)
     @OneToMany(mappedBy = "start", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Connection> connectionsAsStart = new ArrayList<>();
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
@@ -1,0 +1,63 @@
+package com.example.starlet_be.domains.star.entity;
+
+import com.example.starlet_be.domains.connection.connection.Connection;
+import com.example.starlet_be.domains.constellation.entity.Constellation;
+import com.example.starlet_be.domains.diary.entity.Color;
+import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Star {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Color color;
+
+    @Column(nullable = false)
+    private Double x;
+
+    @Column(nullable = false)
+    private Double y;
+
+    @ManyToOne
+    @JoinColumn(name = "constellation_id")
+    private Constellation constellation;
+
+    @OneToOne
+    @JoinColumn(name = "diary_id")
+    private Diary diary;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // Star.java에 추가 (이 방법은 복잡성이 증가하여 특별한 이유가 없다면 추천하지 않습니다)
+    @OneToMany(mappedBy = "start", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Connection> connectionsAsStart = new ArrayList<>();
+
+    @OneToMany(mappedBy = "end", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Connection> connectionsAsEnd = new ArrayList<>();
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/entity/User.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/entity/User.java
@@ -1,6 +1,9 @@
 package com.example.starlet_be.domains.user.entity;
 
+import com.example.starlet_be.domains.constellation.entity.Constellation;
+import com.example.starlet_be.domains.diary.entity.Diary;
 import com.example.starlet_be.domains.email.entity.Email;
+import com.example.starlet_be.domains.star.entity.Star;
 import com.example.starlet_be.domains.user.resdto.UserResDto;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -24,9 +27,18 @@ public class User{
     @Column(nullable = false)
     private String password;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.REMOVE, orphanRemoval = true)
     @JoinColumn(name = "email_id", nullable = false)
     private Email email;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Star> stars = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Diary> diaries = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Constellation> constellations = new ArrayList<>();
 
     @Builder public User(String nickname, String password, Email email) {
         this.nickname = nickname;

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/service/UserService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/service/UserService.java
@@ -137,12 +137,13 @@ public class UserService {
     public void deleteCurrentUser(String email) {
         User user = userRepository.findByEmailAddress(email).orElseThrow(
                 () -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        Email userEmail = user.getEmail();
-        Verify userVerify = userEmail.getVerify();
+//        Email userEmail = user.getEmail();
+//        Verify userVerify = userEmail.getVerify();
 
+        // Cascade 설정으로 나머지 주석처리
         userRepository.delete(user);
-        emailRepository.delete(userEmail);
-        verifyRepository.delete(userVerify);
+//        emailRepository.delete(userEmail);
+//        verifyRepository.delete(userVerify);
     }
 
     // 이메일 기반 찾기

--- a/Starlet_BE/src/main/resources/application.yml
+++ b/Starlet_BE/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## PR 요약
- ERD에 작성했던 엔티티들의 연관관계들을 설정하였습니다.

---

## 변경 내용
- 엔티티 연관관계 설정
- User, Email, Verify 생명주기 연동에 의한 불필요 삭제 메소드 임시 주석처리
- DB구조의 잦은 변화로 서버 실행 시 DB 초기화 설정

---

## 관련 이슈
- 로컬에서 실행하실 땐 update로 놓고 사용하셔도 되나, 완전히 DB구조가 확정나기 전까지는 create-drop을 원칙으로 하겠습니다.
