### PR TITLE
Fix/token

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/service/UserService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/service/UserService.java
@@ -97,6 +97,8 @@ public class UserService {
         Verify verify = user.getEmail().getVerify();
         if(verify.getType() == VerifyType.REQUEST_PASSWORD_RESET){
             verify.setType(VerifyType.VERIFY);
+            verify.setToken(null);
+            verify.setExpireTime(null);
             verifyRepository.save(verify);
         } else if(verify.getType() != VerifyType.VERIFY) {
             throw new CustomException(ErrorCode.NOT_VERIFY_USER);

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
@@ -68,7 +68,7 @@ public class VerifyService {
 
     // 가입 인증 상태가 만료되면 이메일 객체와 인증 객체 삭제
     // 비밀번호 변경 요청이었다면 이거는 그냥 만료시킴
-    @Scheduled(cron = "0 * * * * *") // 1분마다 실행
+    @Scheduled(cron = "0 */30 * * * *") // 1분마다 실행
     @Transactional
     public void cleanExpiredVerify(){
         List<Verify> expireList = verifyRepository.findAllByExpireTimeBefore(LocalDateTime.now());


### PR DESCRIPTION
## PR 요약
- 비밀번호 변경 요청 철회 시 토큰과 만료기간을 null로 리셋하지 않는 오류를 수정하였습니다.

---

## 변경 내용
- 로그인 시 비밀번호 변경 요청 상태에서 토큰과 만료기간을 null로 세팅하고 인증된 계정으로 다시 변경
- 인증만료 이메일 검사 스케줄 주기 1분 -> 30분으로 조정