### PR TITLE
feat : s3 관련 presigned url 발급 API 구현

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/Config/S3Config.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/Config/S3Config.java
@@ -7,45 +7,45 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
 
-    @Value("${s3.bucket}")
-    private String bucket;
-
     @Value("${s3.region}")
     private String region;
 
-    @Value("${s3.access-key}")
+    @Value("${s3.access-key:}")
     private String accessKey;
 
-    @Value("${s3.secret-key}")
+    @Value("${s3.secret-key:}")
     private String secretKey;
 
 
     @Bean
     public S3Presigner s3Presigner() {
-        return S3Presigner.builder()
-                .region(Region.of(region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(accessKey, secretKey)
-                        )
-                )
-                .build();
+        S3Presigner.Builder builder = S3Presigner.builder()
+                .region(Region.of(region));
+
+        if (!accessKey.isBlank() && !secretKey.isBlank()) {
+            builder.credentialsProvider(
+                    StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+            );
+        }
+        return builder.build();
     }
 
     @Bean
     public S3Client s3Client() {
-        return S3Client.builder()
-                .region(Region.of(region))
-                .credentialsProvider(
-                        StaticCredentialsProvider.create(
-                                AwsBasicCredentials.create(accessKey, secretKey)
-                        )
-                )
-                .build();
+        S3ClientBuilder builder = S3Client.builder()
+                .region(Region.of(region));
+
+        if (!accessKey.isBlank() && !secretKey.isBlank()) {
+            builder.credentialsProvider(
+                    StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey))
+            );
+        }
+        return builder.build();
     }
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/Config/S3Config.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/Config/S3Config.java
@@ -1,0 +1,51 @@
+package com.example.starlet_be.domains.S3.Config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${s3.bucket}")
+    private String bucket;
+
+    @Value("${s3.region}")
+    private String region;
+
+    @Value("${s3.access-key}")
+    private String accessKey;
+
+    @Value("${s3.secret-key}")
+    private String secretKey;
+
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(
+                        StaticCredentialsProvider.create(
+                                AwsBasicCredentials.create(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/Controller/S3Controller.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/Controller/S3Controller.java
@@ -1,0 +1,42 @@
+package com.example.starlet_be.domains.S3.Controller;
+
+import com.example.starlet_be.domains.S3.dto.S3tempResDto;
+import com.example.starlet_be.domains.S3.dto.S3uploadResDto;
+import com.example.starlet_be.domains.S3.service.S3StorageService;
+import com.example.starlet_be.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import com.example.starlet_be.domains.user.entity.User;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final S3StorageService s3StorageService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/image/tempUrl")
+    public S3tempResDto tempUrl(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam String contentType
+    ) {
+        Long userId = resolveUserId(principal);
+        String key = String.format("uploads/users/%d/%s.png", userId, UUID.randomUUID());
+        URL presignedUrl = s3StorageService.createUploadUrl(key, contentType);
+        return S3tempResDto.of(presignedUrl, key);
+    }
+
+    private Long resolveUserId(UserDetails principal) {
+        String email = principal.getUsername();
+        return userRepository.findByEmailAddress(email)
+                .map(User::getId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다: " + email));
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/dto/S3tempResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/dto/S3tempResDto.java
@@ -1,0 +1,26 @@
+package com.example.starlet_be.domains.S3.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.net.URL;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class S3tempResDto {
+
+    @Schema(example = "https://starlet-s3-bucket.s3.ap-northeast-2.amazonaws.com/uploads/users/123/abc.png?...signature=...")
+    private String presignedUrl;
+
+    @Schema(example = "uploads/users/{userId}/abc.png")
+    private String tempKey;
+
+    public static S3tempResDto of(URL url, String key) {
+        return S3tempResDto.builder()
+                .presignedUrl(url.toString())
+                .tempKey(key)
+                .build();
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/dto/S3uploadResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/dto/S3uploadResDto.java
@@ -1,0 +1,21 @@
+package com.example.starlet_be.domains.S3.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class S3uploadResDto {
+
+    @Schema(example = "")
+    private String imageUrl;
+
+    public static S3uploadResDto of(String url) {
+        return S3uploadResDto.builder()
+                .imageUrl(url)
+                .build();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/service/S3StorageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/service/S3StorageService.java
@@ -1,0 +1,72 @@
+package com.example.starlet_be.domains.S3.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URL;
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class S3StorageService {
+
+    private final S3Presigner presigner;
+    private final S3Client s3Client;
+
+    @Value("${s3.bucket}")
+    private String bucket;
+
+    @Value("${s3.region}")
+    private String region;
+
+    /**
+     * 임시 저장용 사진을 위한 presignedUrl 발급
+     *
+     * @param key 임시 발급한 key
+     * @param contentType 이미지 타입
+     * @return 발급한 presigned url
+     */
+    public URL createUploadUrl(String key, String contentType) {
+        PutObjectRequest putReq = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignReq = PutObjectPresignRequest.builder()
+                .putObjectRequest(putReq)
+                .signatureDuration(Duration.ofMinutes(10))
+                .build();
+
+        return presigner.presignPutObject(presignReq).url();
+    }
+
+    /**
+     * 확정된 사진의 tempkey를 받아서, 최종 사진 url을 저장
+     *
+     * @param userId 사용자 id
+     * @param tempKey 저장할 사진의 key
+     * @return 최종 사진 url
+     */
+    public String publishProfile(Long userId, String tempKey) {
+        String publicKey = "public/users/" + userId + "/profile.png";
+
+        CopyObjectRequest copyReq = CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(tempKey)
+                .destinationBucket(bucket)
+                .destinationKey(publicKey)
+                .build();
+
+        s3Client.copyObject(copyReq);
+
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucket, region, publicKey);
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/service/S3StorageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/S3/service/S3StorageService.java
@@ -33,6 +33,10 @@ public class S3StorageService {
      * @return 발급한 presigned url
      */
     public URL createUploadUrl(String key, String contentType) {
+        if (!contentType.startsWith("image/")) {
+            throw new IllegalArgumentException("이미지 contentType만 허용됩니다.");
+        }
+
         PutObjectRequest putReq = PutObjectRequest.builder()
                 .bucket(bucket)
                 .key(key)
@@ -55,6 +59,12 @@ public class S3StorageService {
      * @return 최종 사진 url
      */
     public String publishProfile(Long userId, String tempKey) {
+
+        String allowedPrefix = "uploads/users/" + userId + "/";
+        if (tempKey == null || !tempKey.startsWith(allowedPrefix)) {
+            throw new IllegalArgumentException("잘못된 tempKey입니다.");
+        }
+
         String publicKey = "public/users/" + userId + "/profile.png";
 
         CopyObjectRequest copyReq = CopyObjectRequest.builder()

--- a/Starlet_BE/src/main/resources/application.yml
+++ b/Starlet_BE/src/main/resources/application.yml
@@ -47,10 +47,10 @@ app:
 
 
 s3:
-  bucket: ${AWS_S3_BUCKET}
-  region: ${AWS_REGION}
-  access-key: ${AWS_S3_ACCESSKEY}
-  secret-key: ${AWS_S3_SECRETKEY}
+  bucket: starlet-s3-bucket
+  region: ap-northeast-2
+  access-key: ${AWS_S3_ACCESSKEY:}
+  secret-key: ${AWS_S3_SECRETKEY:}
 
 openai:
   api:


### PR DESCRIPTION
## PR 요약
- #50
- **presigned url**을 발급해주는 API 구현
- /uploads/... 에 저장된 임시 사진 중 최종 사진의 temp key를 받아 실제 루트인 /public/... 로 copy하는 서비스 구현

---

## 변경 내용
#### 사진 업로드 사용 방법
1. 사용자가 사진을 선택할 때마다 **presigned url** 발급
2. 서버에서 **presigend url**과 **temp key** 제공 (/uploads/.. 루트로 저장)
3. 프론트에서 해당 **presigned** `PUT` 로 사용자가 업로드한 사진을 s3에 저장
4. 최종 저장 시 해당 사진의 **temp key**를 담아 백엔드에 전송
#엔드포인트 하나로 구현할 예정입니다.
5. 백엔드는 해당 **temp key**를 보고, 
5.1 최종 저장 루트로 사진 copy 수행
5.2 실제 url (/public/... 루트) 을 서버 단에서 만든 후 db에 저장

---

## 관련 이슈
- 마이페이지 수정 API 구현 시 하나의 엔드포인트로 temp key 받도록 구현할 것
- db에 사진 url을 저장할 때, **url**로 저장할지 **key**로 저장할지 고민해볼 것 (아마 **key**로 저장할 것 같습니다.)
