### PR TITLE
이메일 발송 및 로그인 조건 설정 변경

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/controller/EmailAPI.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/controller/EmailAPI.java
@@ -63,12 +63,12 @@ public interface EmailAPI {
     @Operation(summary = "가입가능 이메일 인증메일 발송", description = "가입할 이메일 주소에 대해 인증메일을 발송합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "이메일 발송 성공"),
-            @ApiResponse(responseCode = "409", description = "이메일 중복",
+            @ApiResponse(responseCode = "409", description = "이미 가입된 회원",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     {
                                         "status": 409,
-                                        "message": "이메일이 중복됩니다."
+                                        "message": "해당 이메일로 가입한 사용자가 이미 존재합니다."
                                     }
                                     """)
                     })),

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/service/EmailService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/service/EmailService.java
@@ -142,6 +142,10 @@ public class EmailService {
     public void initEmail(EmailAddressDto dto){
 
         if(emailRepository.existsByAddress(dto.getEmail())){
+            // 이미 가입되어있으면 방어
+            if(userRepository.existsByEmailAddress(dto.getEmail()))
+                throw new CustomException(ErrorCode.USER_ALREADY_EXIST);
+
             // 인증정보 불러오기
             Verify verify = verifyRepository.findByEmail_Address(dto.getEmail()).orElseThrow(
                     () -> new CustomException(ErrorCode.VERIFY_NOT_FOUND)

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/service/EmailService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/email/service/EmailService.java
@@ -5,9 +5,12 @@ import com.example.starlet_be.domains.email.repository.EmailRepository;
 import com.example.starlet_be.domains.email.reqdto.EmailAddressDto;
 import com.example.starlet_be.domains.email.resdto.EmailInfoDto;
 import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.domains.user.entity.enums.TokenType;
 import com.example.starlet_be.domains.user.repository.UserRepository;
 import com.example.starlet_be.domains.user.service.UserService;
 import com.example.starlet_be.domains.verify.entity.Verify;
+import com.example.starlet_be.domains.verify.entity.VerifyType;
+import com.example.starlet_be.domains.verify.repository.VerifyRepository;
 import com.example.starlet_be.domains.verify.service.VerifyService;
 import com.example.starlet_be.exception.CustomException;
 import com.example.starlet_be.exception.ErrorCode;
@@ -21,6 +24,8 @@ import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+
 /**
  * 이메일(Email) 서비스
  *
@@ -33,6 +38,7 @@ public class EmailService {
     private final EmailRepository emailRepository;
     private final VerifyService verifyService;
     private final UserRepository userRepository;
+    private final VerifyRepository verifyRepository;
 
     @Value("${app.frontend.base-url}")
     private String baseUrl;
@@ -128,19 +134,41 @@ public class EmailService {
      * 초기 가입 인증 이메일 전송
      *
      * 사용가능한 이메일인 경우 해당 메소드가 실행되어 인증을 요구하게됨
+     * 이메일을 재전송할 수 있게 아래와 같이 구현함
      *
      * @param dto 이메일 주소
      */
     @Transactional
     public void initEmail(EmailAddressDto dto){
-        // 인증 객체 최초 생성
-        Verify verify = verifyService.createVerify();
 
-        // 이메일 생성 후 인증객체 붙이기
-        Email email = createEmail(dto.getEmail(), verify);
+        if(emailRepository.existsByAddress(dto.getEmail())){
+            // 인증정보 불러오기
+            Verify verify = verifyRepository.findByEmail_Address(dto.getEmail()).orElseThrow(
+                    () -> new CustomException(ErrorCode.VERIFY_NOT_FOUND)
+            );
+            // 인증정보 최신화
+            verify.updateStatus(
+                    verifyService.createToken(),
+                    VerifyType.EMAIL_VERIFICATION,
+                    LocalDateTime.now().plusHours(8)
+            );
+            // 저장
+            verifyRepository.save(verify);
 
-        // 인증 이메일 전송
-        sendVerificationEmail(email, verify.getToken());
+            sendVerificationEmail(
+                    findEmailByAddress(dto.getEmail()),
+                    verify.getToken()
+            );
+        } else {
+            // 인증 객체 최초 생성
+            Verify verify = verifyService.createVerify();
+
+            // 이메일 최초 생성 후 인증 이메일 전송
+            sendVerificationEmail(
+                    createEmail(dto.getEmail(), verify),
+                    verify.getToken()
+            );
+        }
     }
 
     /**
@@ -148,6 +176,8 @@ public class EmailService {
      *
      * 사용자가 비밀번호를 잊어버렸을경우 인증 메일을 전송한다.
      * 해당 계정을 비밀번호 요청 상태로 변경한 후 메일을 전송한다.
+     *
+     * VerifyService에 의해서 인증 상태를 검사하니 해당 메소드를 따라갈 것.
      *
      * 이메일 기반으로 검색해서 사용자가 없을경우 USER_NOT_FOUND
      *

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/service/UserService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/service/UserService.java
@@ -127,7 +127,7 @@ public class UserService {
      * 가입된 사용자가 존재하지 않으면 USER_NOT_FOUND 응답
      * 비밀번호가 틀리면 INCORRECT_PASSWORD 응답
      * 인증상태가 비정상적일 경우 NOT_VERIFY_USER 응답
-     * 비밀번호 초기화 요청상태에서 로그인을 성공할경우 요청 철회 후 정상계정으로 변경
+     * 가입된 모든 상태(비밀번호 변경 절차 포함)에서 로그인을 성공할경우 정상계정으로 변경
      * 프론트엔드 작업 끝나기전까지 헤더와 응답에 모두 AccessToken 및 RefreshToken 반영
      *
      * @param dto 로그인에 필요한 정보. 이메일 및 비밀번호
@@ -147,10 +147,12 @@ public class UserService {
 
         // 3. 인증상태 검증 - 초기화 요청했던 계정은 그냥 로그인 성공했으므로 철회, 나머지는 방어
         Verify verify = user.getEmail().getVerify();
-        if(verify.getType() == VerifyType.REQUEST_PASSWORD_RESET){
+        if(verify.getType() == VerifyType.REQUEST_PASSWORD_RESET
+        || verify.getType() == VerifyType.CHANGING_PASSWORD){
             verify.updateStatus(null, VerifyType.VERIFY, null);
             verifyRepository.save(verify);
-        } else if(verify.getType() != VerifyType.VERIFY) {
+        }
+        if(verify.getType() == VerifyType.EMAIL_VERIFICATION) {
             throw new CustomException(ErrorCode.NOT_VERIFY_USER);
         }
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/entity/Verify.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/entity/Verify.java
@@ -37,7 +37,8 @@ public class Verify {
     private Email email;
 
 
-    @Builder public Verify(String token, VerifyType type, LocalDateTime expireTime) {
+    @Builder
+    public Verify(String token, VerifyType type, LocalDateTime expireTime) {
         this.token = token;
         this.type = type;
         this.expireTime = expireTime;

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/repository/VerifyRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/repository/VerifyRepository.java
@@ -11,4 +11,6 @@ public interface VerifyRepository extends JpaRepository<Verify, Long> {
     Optional<Verify> findByToken(String token);
 
     List<Verify> findAllByExpireTimeBefore(LocalDateTime now);
+
+    Optional<Verify> findByEmail_Address(String emailAddress);
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
@@ -37,7 +37,7 @@ public class VerifyService {
      * 토큰 문자열 랜덤 생성
      * @return String
      */
-    private String createToken(){
+    public String createToken(){
         return UUID.randomUUID().toString();
     }
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
@@ -96,7 +96,7 @@ public class VerifyService {
      * 비밀번호 변경 요청이었다면 이거는 그냥 만료시킴
      *
      */
-    @Scheduled(cron = "0 */30 * * * *") // 1분마다 실행
+    @Scheduled(cron = "0 */30 * * * *") // 30분마다 실행
     @Transactional
     public void cleanExpiredVerify(){
         List<Verify> expireList = verifyRepository.findAllByExpireTimeBefore(LocalDateTime.now());
@@ -139,7 +139,7 @@ public class VerifyService {
      *
      * VERIFY -> REQUEST_PASSWORD_RESET
      *
-     * 이전에 VERIFY가 아닌 계정이 초기화하려할 때, VERIFY_TYPE_NOT_MATCHED -> 이 부분은 메일 재전송을 위해 고칠 가능성 있음
+     * 가입된 계정 범위 안에서 초기화 이메일을 계속 전송할 수 있음.
      *
      * @param email 이메일 객체
      */

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/verify/service/VerifyService.java
@@ -149,8 +149,8 @@ public class VerifyService {
         // 1. 이메일의 인증정보 가져오기
         Verify verify = email.getVerify();
 
-        // 2. 원래 정상인 계정이었는지
-        if(verify.getType() != VerifyType.VERIFY)
+        // 2. 가입 된 계정이 아니라면
+        if(verify.getType() == VerifyType.EMAIL_VERIFICATION)
             throw new CustomException(ErrorCode.VERIFY_TYPE_NOT_MATCHED);
 
         // 3. 비밀번호 초기화 요청 상태로 변경과, 인증 유효 토큰 부여

--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     // 유저 관련
     USER_NOT_FOUND(404, "해당 유저를 찾을 수 없습니다."),
     INCORRECT_PASSWORD(400, "비밀번호가 일치하지 않습니다."),
+    USER_ALREADY_EXIST(409, "해당 이메일로 가입한 사용자가 이미 존재합니다."),
     NICKNAME_CONFLICT(409, "닉네임이 중복됩니다."),
     DUPLICATE_INFO_CONFLICT(409, "이미 사용중인 정보가 있습니다. 이메일과 닉네임 중복검사를 시행하세요."),
     USER_CREATE_FAILED(500, "유저 생성에 실패하였습니다."),

--- a/Starlet_BE/src/main/resources/application.yml
+++ b/Starlet_BE/src/main/resources/application.yml
@@ -24,7 +24,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
 
   ai:
     openai:


### PR DESCRIPTION
## PR 요약
- 이메일 발송과 로그인 조건을 더 느슨하게 바꾸었고 환경설정을 조금 수정하였습니다.
---

## 변경 내용
- 가입 이메일 재전송 가능하도록 수정
- 비밀번호 변경 이메일 재전송 가능하도록 수정
- 비밀번호 변경 요청, 변경 승인상태에서 이전 비밀번호로 로그인이 가능하도록 수정
- MySQL 8.x 버전으로 호환성 맞춤 설정
- 가입된 계정으로 가입 이메일 전송이 가능했던 버그 수정
- 가입로직 Swagger 수정
- 가입로직 오류코드 추가
