### PR TITLE
feat : diary 엔티티 race condition 방지

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/entity/Diary.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/entity/Diary.java
@@ -14,13 +14,17 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
+@Table(
+        name = "diary",
+        uniqueConstraints = @UniqueConstraint(name = "uk_diary_user_date", columnNames = {"user_id", "create_at"})
+)
 public class Diary {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    @JoinColumn(name = "user_id")
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Column(nullable = false)
@@ -39,7 +43,7 @@ public class Diary {
     @Column
     private String content;
 
-    @Column(nullable = false)
+    @Column(name = "create_at", nullable = false)
     private LocalDate createAt;
 
     @OneToOne(mappedBy = "diary", cascade = CascadeType.REMOVE, orphanRemoval = true)

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
@@ -14,7 +14,7 @@ import com.example.starlet_be.domains.diary.dto.resdto.StarMonthlyResDto;
 import com.example.starlet_be.domains.user.entity.User;
 import com.example.starlet_be.exception.ErrorCode;
 import jakarta.persistence.EntityManager;
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -52,34 +52,41 @@ public class DiaryService {
      */
     @Transactional
     public DiaryResDto create(Long userId, DiaryCreateReqDto req) {
-        LocalDate date = req.getDate();
+        LocalDate date = (req.getDate() != null) ? req.getDate() : LocalDate.now();
 
         if (diaryRepository.existsByUser_IdAndCreateAt(userId, date)) {
             throw new CustomException(ErrorCode.DIARY_ALREADY_EXISTS);
         }
+        try
+        {
+            User userRef = em.getReference(User.class, userId);
 
-        User userRef = em.getReference(User.class, userId);
+            Diary diary = Diary.builder()
+                    .user(userRef)
+                    .emotion(req.getEmotion())
+                    .factors(safeFactors(req.getFactors()))
+                    .content(req.getContent())
+                    .createAt(date)
+                    .build();
 
-        Diary diary = Diary.builder()
-                .user(userRef)
-                .emotion(req.getEmotion())
-                .factors(safeFactors(req.getFactors()))
-                .content(req.getContent())
-                .createAt(date)
-                .build();
+            diaryRepository.save(diary);
 
-        Star star = Star.builder()
-                .color(diary.getEmotion().getColor())
-                .x(Math.random())
-                .y(Math.random())
-                .user(userRef)
-                .diary(diary)
-                .build();
+            Star star = Star.builder()
+                    .color(diary.getEmotion().getColor())
+                    .x(Math.random())
+                    .y(Math.random())
+                    .user(userRef)
+                    .diary(diary)
+                    .build();
 
-        starRepository.save(star);
-        diaryRepository.save(diary);
+            starRepository.save(star);
 
-        return DiaryResDto.of(diary);
+
+            return DiaryResDto.of(diary);
+        } catch (org.springframework.dao.DataIntegrityViolationException e) {
+            throw new CustomException(ErrorCode.DIARY_ALREADY_EXISTS);
+        }
+
     }
 
     /**

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
@@ -50,7 +50,7 @@ public class Star {
     private Constellation constellation;
 
     @OneToOne
-    @JoinColumn(name = "diary_id")
+    @JoinColumn(name = "diary_id", nullable = false, unique = true)
     private Diary diary;
 
     @ManyToOne


### PR DESCRIPTION
## PR 요약
정님이 발견해주신, 동시에 여러 요청이 들어올 때 발생하던 Diary race condition 문제를 해결했습니다.

- Diary 엔티티에 `(user_id, create_at)` 복합 UNIQUE 제약 추가  
  - 동일 사용자/날짜 중복 작성 방지  
  - DB 락보다 가볍게 처리 (추후에 db락도 필요하다 판단될 경우 추가하겠습니다)
- Diary - Star 생성 순서 변경
- Star 엔티티의 `diary_id` 필드에 UNIQUE 제약 추가
