### PR TITLE
밤하늘 별자리 조회 API 개념적 오류 수정

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/controller/ConstellationApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/controller/ConstellationApi.java
@@ -31,6 +31,7 @@ public interface ConstellationApi {
                                             "userId": 1,
                                             "x": 0.1,
                                             "y": 0.2,
+                                            "belongDate": "2025-09-01"
                                             "stars": [
                                                 {
                                                     "starId": 1,

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/entity/Constellation.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/entity/Constellation.java
@@ -42,10 +42,7 @@ public class Constellation {
     private LocalDate createAt;
 
     @Column
-    private Integer year;
-
-    @Column
-    private Integer month;
+    private LocalDate belongDate;
 
     @Column
     private boolean isRepresentative;
@@ -87,9 +84,8 @@ public class Constellation {
         if(description != null && !description.isBlank()) this.description = description;
     }
 
-    public void setYearAndMonth(Integer year, Integer month) {
-        this.year = year;
-        this.month = month;
+    public void setBelongDate(LocalDate belongDate) {
+        this.belongDate = belongDate;
     }
 
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/entity/Constellation.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/entity/Constellation.java
@@ -42,6 +42,12 @@ public class Constellation {
     private LocalDate createAt;
 
     @Column
+    private Integer year;
+
+    @Column
+    private Integer month;
+
+    @Column
     private boolean isRepresentative;
 
     @Column(nullable = false)
@@ -79,6 +85,11 @@ public class Constellation {
     public void updateInfo(String name, String description) {
         if(name != null && !name.isBlank()) this.name = name;
         if(description != null && !description.isBlank()) this.description = description;
+    }
+
+    public void setYearAndMonth(Integer year, Integer month) {
+        this.year = year;
+        this.month = month;
     }
 
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ConstellationRepository extends JpaRepository<Constellation, Long> {
-    List<Constellation> findByUserAndCreateAtBetween(User user, LocalDate startDate, LocalDate endDate);
+    List<Constellation> findByUserAndBelongDateBetween(User user, LocalDate startDate, LocalDate endDate);
     List<Constellation> findByUser(User user);
 
     Optional<Constellation> findByUserAndIsRepresentative(User user, boolean isRepresentative);

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/resdto/StarryNightConstellationDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/resdto/StarryNightConstellationDto.java
@@ -5,6 +5,7 @@ import com.example.starlet_be.domains.star.resdto.StarryNightStarDto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Getter
@@ -14,6 +15,8 @@ public class StarryNightConstellationDto {
     private Long userId;
     private Double x;
     private Double y;
+
+    private LocalDate belongDate;
 
 
     // 각 별에 대한 정보 리스트
@@ -25,11 +28,16 @@ public class StarryNightConstellationDto {
 
 
     @Builder
-    public StarryNightConstellationDto(Long constellationId, Long userId, Double x, Double y, List<StarryNightStarDto> stars, List<StarryNightConnectionDto> connections) {
+    public StarryNightConstellationDto(
+            Long constellationId, Long userId,
+            Double x, Double y, LocalDate belongDate,
+            List<StarryNightStarDto> stars,
+            List<StarryNightConnectionDto> connections) {
         this.constellationId = constellationId;
         this.userId = userId;
         this.x = x;
         this.y = y;
+        this.belongDate = belongDate;
         this.stars = stars;
         this.connections = connections;
     }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -184,6 +184,7 @@ public class ConstellationService {
                             .userId(con.getUser().getId())
                             .x(con.getX())
                             .y(con.getY())
+                            .belongDate(con.getBelongDate())
                             .stars(starsInfo)
                             .connections(connectionsInfo)
                             .build()

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -75,7 +75,6 @@ public class ConstellationService {
                 .x(Math.random())
                 .y(Math.random())
                 .build();
-        constellationRepository.save(constellation);
 
         // 별들 저장
         for(StarPositionDto starDto : dto.getStars()){
@@ -104,10 +103,9 @@ public class ConstellationService {
         }
 
         // 별자리가 속한 월 저장, 그냥 아무 별이나 가져와서 소속 연도와 월을 저장
-        constellation.setYearAndMonth(
-                constellation.getStars().get(0).getDiary().getCreateAt().getYear(),
-                constellation.getStars().get(0).getDiary().getCreateAt().getMonthValue()
-        );
+        constellation.setBelongDate(constellation.getStars().get(0).getDiary().getCreateAt());
+
+        constellationRepository.save(constellation);
 
     }
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -75,6 +75,7 @@ public class ConstellationService {
                 .x(Math.random())
                 .y(Math.random())
                 .build();
+        constellationRepository.save(constellation);
 
         // 별들 저장
         for(StarPositionDto starDto : dto.getStars()){
@@ -102,8 +103,11 @@ public class ConstellationService {
             );
         }
 
-        // 별자리가 속한 월 저장, 그냥 아무 별이나 가져와서 소속 연도와 월을 저장
-        constellation.setBelongDate(constellation.getStars().get(0).getDiary().getCreateAt());
+        // 별자리가 속한 월 저장, 그냥 아무 별이나 가져와서 일기 생성일자 저장
+
+        Star star = starRepository.findByConstellation(constellation).get(0);
+
+        constellation.setBelongDate(star.getDiary().getCreateAt());
 
         constellationRepository.save(constellation);
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -144,7 +144,7 @@ public class ConstellationService {
 
         // 해당 분기의 별자리 불러오기
         List<Constellation> constellations =
-                constellationRepository.findByUserAndCreateAtBetween(user, startDate, endDate);
+                constellationRepository.findByUserAndBelongDateBetween(user, startDate, endDate);
 
         List<StarryNightConstellationDto> constellationsInfo = new ArrayList<>();
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -102,6 +102,13 @@ public class ConstellationService {
                             .build()
             );
         }
+
+        // 별자리가 속한 월 저장, 그냥 아무 별이나 가져와서 소속 연도와 월을 저장
+        constellation.setYearAndMonth(
+                constellation.getStars().get(0).getDiary().getCreateAt().getYear(),
+                constellation.getStars().get(0).getDiary().getCreateAt().getMonthValue()
+        );
+
     }
 
     /**

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/entity/Star.java
@@ -19,7 +19,6 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 


### PR DESCRIPTION
## PR 요약
- 밤하늘 별자리 조회 시 별자리 생성일 기준으로 조회하는 부분이 있었습니다. 이 부분은 기획 의도와 다르게 동작하여 별들이 소속된 월에 조회되도록 수정하였습니다.

---

## 변경 내용
- Constellation에 createAt - 별자리생성일, belongDate - 별들이 속한 분기(List 첫번째 별의 날짜 복사)로 날짜 개념 분리
   - 별자리 아카이브에서의 date필드는 별도로 건드리지 않았습니다. 이건 createAt을 뜻합니다.
   - 밤하늘 별자리에서는 belongDate를 반환하도록 수정하였습니다. (not null 조건은 넣지 않았습니다.)
- 수정사항에 대해서 Swagger에도 수정사항을 남겼습니다.

---

## 관련 이슈
- DB Constellation Table 속성관련 문제 발생 우려 - belong_date 속성 테이블 자동 추가 후 만약 밤하늘 별자리를 조회할 시 null으로 초기화 되어있던 기존 레코드들이 불러와지지 않는 문제가 발생할 수 있으므로, 기존 별자리에 수동으로 날짜를 추가해야함을 인지하고 계시면 됩니다.
