### PR TITLE
feat : 마이페이지 관련 API 구현 완료

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/S3/dto/PublishedObject.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/S3/dto/PublishedObject.java
@@ -1,0 +1,11 @@
+package com.example.starlet_be.S3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class PublishedObject {
+    private final String key;
+    private final String url;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/S3/service/S3StorageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/S3/service/S3StorageService.java
@@ -1,5 +1,6 @@
 package com.example.starlet_be.S3.service;
 
+import com.example.starlet_be.S3.dto.PublishedObject;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -58,7 +59,7 @@ public class S3StorageService {
      * @param tempKey 저장할 사진의 key
      * @return 최종 사진 url
      */
-    public String publishProfile(Long userId, String tempKey) {
+    public PublishedObject publishProfile(Long userId, String tempKey) {
 
         String allowedPrefix = "uploads/users/" + userId + "/";
         if (tempKey == null || !tempKey.startsWith(allowedPrefix)) {
@@ -76,7 +77,9 @@ public class S3StorageService {
 
         s3Client.copyObject(copyReq);
 
-        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+        String url = String.format("https://%s.s3.%s.amazonaws.com/%s",
                 bucket, region, publicKey);
+
+        return PublishedObject.of(publicKey, url);
     }
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
@@ -13,4 +13,10 @@ public interface ConstellationRepository extends JpaRepository<Constellation, Lo
     List<Constellation> findByUser(User user);
 
     Optional<Constellation> findByUserAndIsRepresentative(User user, boolean isRepresentative);
+
+    // 총 별자리 수
+    long countByUser(User user);
+
+    List<Constellation> findAllByUserAndCreateAtBetween(User user, LocalDate start, LocalDate end);
+
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/repository/DiaryRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/repository/DiaryRepository.java
@@ -1,6 +1,7 @@
 package com.example.starlet_be.domains.diary.repository;
 
 import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -9,16 +10,16 @@ import java.util.Optional;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
 
-    //1. 사용자/날짜의 일기 존재 여부
     boolean existsByUser_IdAndCreateAt(Long userId, LocalDate date);
 
-    //2. 일기 조회
     Optional<Diary> findByUser_IdAndCreateAt(Long userId, LocalDate date);
 
-    //3. 달력 안 별 조회
     List<Diary> findAllByUser_IdAndCreateAtBetweenOrderByCreateAtAsc(
             Long userId, LocalDate from, LocalDate to
     );
 
     Optional<Diary> findByIdAndUser_Id(Long diaryId, Long userId);
+
+    List<Diary> findAllByUserAndCreateAtBetween(User user, LocalDate start, LocalDate end);
+
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/controller/mypageController.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/controller/mypageController.java
@@ -1,0 +1,111 @@
+package com.example.starlet_be.domains.mypage.controller;
+
+import com.example.starlet_be.domains.mypage.dto.*;
+import com.example.starlet_be.domains.mypage.service.MyPageService;
+import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/mypage")
+@RequiredArgsConstructor
+public class mypageController {
+
+    private final MyPageService myPageService;
+    private final UserRepository userRepository;
+
+    // summary
+    @GetMapping("/summary")
+    public ResponseEntity<MyPageSummaryResDto> getSummary(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam(required = false) Integer year,
+            @RequestParam(required = false) Integer month
+    ) {
+        Long userId = resolveUserId(principal);
+        MyPageSummaryResDto body = myPageService.getSummary(userId, year, month);
+        return ResponseEntity.ok(body);
+    }
+
+    // 프로필 조회 api
+    @GetMapping("/user")
+    public ResponseEntity<UserSummaryResDto> getUserSummary(@AuthenticationPrincipal UserDetails principal) {
+        Long userId = resolveUserId(principal);
+        UserSummaryResDto body = myPageService.getUserSummary(userId);
+        return ResponseEntity.ok(body);
+    }
+
+    // 레벨 조회 api
+    @GetMapping("/level")
+    public ResponseEntity<LevelResDto> getLevel(@AuthenticationPrincipal UserDetails principal) {
+        Long userId = resolveUserId(principal);
+        LevelResDto body = myPageService.getLevel(userId);
+        return ResponseEntity.ok(body);
+    }
+
+    // 대표 별자리 조회 api
+    @GetMapping("/representative")
+    public ResponseEntity<?> getRepresentative(@AuthenticationPrincipal UserDetails principal) {
+        Long userId = resolveUserId(principal);
+        var dto = myPageService.getRepresentativeConstellation(userId);
+        return (dto == null) ? ResponseEntity.noContent().build() : ResponseEntity.ok(dto);
+    }
+
+    // 연간 별자리 통계 조회
+    @GetMapping("/year")
+    public ResponseEntity<List<MonthlyCountResDto>> getMonthlyCount(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam(required = false) Integer year) {
+        Long userId = resolveUserId(principal);
+        List<MonthlyCountResDto> stats = myPageService.getMonthlyCount(userId, year);
+
+        return ResponseEntity.ok(stats);
+    }
+
+    //월별 감정 통계 조회
+    @GetMapping("/month")
+    public ResponseEntity<List<EmotionCountResDto>> getEmotionCount(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam int year,
+            @RequestParam int month ) {
+        Long userId = resolveUserId(principal);
+        List<EmotionCountResDto> body = myPageService.getEmotionCount(userId, year, month);
+        return ResponseEntity.ok(body);
+    }
+
+    //프로필 사진 확정
+    @PostMapping("/photo/confirm")
+    public ResponseEntity<ConfirmPhotoResDto> confirmPhoto(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestBody @Valid ConfirmPhotoReqDto req) {
+        Long userId = resolveUserId(principal);
+        ConfirmPhotoResDto body = myPageService.confirmProfilePhoto(userId, req.getTempKey());
+        return ResponseEntity.ok(body);
+    }
+
+    //프로필 닉네임 수정
+    @PatchMapping("/nickname")
+    public ResponseEntity<UpdateNicknameResDto> updateNickname(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestBody @Valid UpdateNicknameReqDto req
+    ) {
+        Long userId = resolveUserId(principal);
+        UpdateNicknameResDto body = myPageService.updateNickname(userId, req.getNickname());
+        return ResponseEntity.ok(body);
+    }
+
+
+
+    private Long resolveUserId(UserDetails principal) {
+        String email = principal.getUsername();
+        return userRepository.findByEmailAddress(email)
+                .map(User::getId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다: " + email));
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/ConfirmPhotoReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/ConfirmPhotoReqDto.java
@@ -1,0 +1,12 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ConfirmPhotoReqDto {
+    @NotBlank
+    private String tempKey;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/ConfirmPhotoResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/ConfirmPhotoResDto.java
@@ -1,0 +1,10 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class ConfirmPhotoResDto {
+    private String url;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/EmotionCountResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/EmotionCountResDto.java
@@ -1,0 +1,17 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class EmotionCountResDto {
+    @Schema(example = "HAPPINESS")
+    private String emotion;
+
+    @Schema(example = "2")
+    private long count;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/LevelResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/LevelResDto.java
@@ -1,0 +1,32 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LevelResDto{
+
+    @Schema(example="STARLIGHT_EXPLORER")
+    private String code;
+
+    @Schema(example = "별빛 탐험가")
+    private String name;
+
+    @Schema(example = "0")
+    private Integer min;
+
+    @Schema(example = "9")
+    private Integer max;
+
+    @Schema(example = "2")
+    private Integer progressToNext;
+
+}
+
+
+
+

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/MonthlyCountResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/MonthlyCountResDto.java
@@ -1,0 +1,18 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MonthlyCountResDto {
+
+    @Schema(example = "10")
+    private int month;
+
+    @Schema(example = "1")
+    private long count;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/MyPageSummaryResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/MyPageSummaryResDto.java
@@ -1,0 +1,52 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import com.example.starlet_be.domains.constellation.dto.StarryNightConstellationDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class MyPageSummaryResDto {
+
+    private final UserSummaryResDto profile;
+
+    private final LevelResDto level;
+
+    private final StarryNightConstellationDto representativeConstellation;
+
+    private final List<MonthlyCountResDto> monthlyConstellationCounts;
+
+    private final List<EmotionCountResDto> monthlyEmotionCounts;
+
+    @Builder
+    private MyPageSummaryResDto(
+            UserSummaryResDto profile,
+            LevelResDto level,
+            StarryNightConstellationDto representativeConstellation,
+            List<MonthlyCountResDto> monthlyConstellationCounts,
+            List<EmotionCountResDto> monthlyEmotionCounts
+    ) {
+        this.profile = profile;
+        this.level = level;
+        this.representativeConstellation = representativeConstellation;
+        this.monthlyConstellationCounts = monthlyConstellationCounts;
+        this.monthlyEmotionCounts = monthlyEmotionCounts;
+    }
+
+    public static MyPageSummaryResDto of(
+            UserSummaryResDto profile,
+            LevelResDto level,
+            StarryNightConstellationDto rep,
+            List<MonthlyCountResDto> monthlyCounts,
+            List<EmotionCountResDto> emotionCounts
+    ) {
+        return MyPageSummaryResDto.builder()
+                .profile(profile)
+                .level(level)
+                .representativeConstellation(rep)
+                .monthlyConstellationCounts(monthlyCounts)
+                .monthlyEmotionCounts(emotionCounts)
+                .build();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/UpdateNicknameReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/UpdateNicknameReqDto.java
@@ -1,0 +1,12 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UpdateNicknameReqDto {
+    @NotBlank(message = "닉네임을 입력하세요.")
+    @Size(min = 2, max = 10, message = "닉네임은 2~10자여야 합니다.")
+    private String nickname;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/UpdateNicknameResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/UpdateNicknameResDto.java
@@ -1,0 +1,12 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(staticName = "of")
+public class UpdateNicknameResDto {
+    @Schema(example = "수정닉네임")
+    private final String nickname;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/UserSummaryResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/UserSummaryResDto.java
@@ -1,0 +1,31 @@
+package com.example.starlet_be.domains.mypage.dto;
+
+import com.example.starlet_be.domains.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserSummaryResDto{
+
+    @Schema(example = "닉네임")
+    private String nickname;
+
+    @Schema(example = "9")
+    private int totalStars;
+
+    @Schema(example = "1")
+    private int totalConstellations;
+
+    public static UserSummaryResDto of(User user, long totalStars, long totalConstellations) {
+        return UserSummaryResDto.builder()
+                .nickname(user.getNickname())
+                .totalStars((int) totalStars)
+                .totalConstellations((int) totalConstellations)
+                .build();
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/level/LevelPolicy.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/level/LevelPolicy.java
@@ -1,0 +1,36 @@
+package com.example.starlet_be.domains.mypage.level;
+
+import com.example.starlet_be.domains.mypage.dto.LevelResDto;
+
+import java.util.List;
+
+public final class LevelPolicy {
+
+    private record Rule(int min, Integer max, String code, String name) {}
+
+    private static final List<Rule> RULES = List.of(
+            new Rule(0,   9,   "STARLIGHT_EXPLORER",       "별빛 탐험가"),
+            new Rule(10,  29,  "STARCLUSTER_EXPLORER",     "별무리 탐험가"),
+            new Rule(30,  59,  "CONSTELLATION_EXPLORER",   "별자리 탐험가"),
+            new Rule(60,  99,  "NEBULA_EXPLORER",          "성운 탐험가"),
+            new Rule(100, 149, "GALAXY_EXPLORER",          "은하 탐험가"),
+            new Rule(150, 209, "GALAXY_CLUSTER_EXPLORER",  "은하단 탐험가"),
+            new Rule(210, 299, "MILKYWAY_EXPLORER",        "은하수 탐험가"),
+            new Rule(300, null,"UNIVERSE_EXPLORER",        "우주 탐험가")
+    );
+
+    private LevelPolicy() {}
+
+    public static LevelResDto resolve(long totalStars) {
+        for (Rule r : RULES) {
+            boolean geMin = totalStars >= r.min;
+            boolean leMax = (r.max == null) || (totalStars <= r.max);
+            if (geMin && leMax) {
+                Integer progress = (r.max == null) ? null : Math.max(0, r.max - (int) totalStars);
+                return new LevelResDto(r.code, r.name, r.min, r.max, progress);
+            }
+        }
+
+        return new LevelResDto("STARLIGHT_EXPLORER", "별빛 탐험가", 0, 9, Math.max(0, 9 - (int) totalStars));
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/mapper/ConstellationMapper.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/mapper/ConstellationMapper.java
@@ -1,0 +1,48 @@
+package com.example.starlet_be.domains.mypage.mapper;
+
+import com.example.starlet_be.domains.constellation.entity.Constellation;
+import com.example.starlet_be.domains.connection.dto.StarryNightConnectionDto;
+import com.example.starlet_be.domains.star.dto.StarryNightStarDto;
+import com.example.starlet_be.domains.constellation.dto.StarryNightConstellationDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+@Component
+public class ConstellationMapper {
+
+    public StarryNightConstellationDto toStarryNightDto(Constellation c) {
+
+        return StarryNightConstellationDto.builder()
+                .constellationId(c.getId())
+                .userId(c.getUser().getId())
+                .x(c.getX())
+                .y(c.getY())
+                .belongDate(c.getBelongDate())
+
+                .stars(c.getStars() != null
+                        ? c.getStars().stream()
+                        .map(s -> StarryNightStarDto.builder()
+                                .starId(s.getId())
+                                .userId(s.getUser().getId())
+                                .color(String.valueOf(s.getColor()))
+                                .x(s.getX())
+                                .y(s.getY())
+                                .build())
+                        .collect(Collectors.toList())
+                        : Collections.emptyList())
+
+                .connections(c.getConnections() != null
+                        ? c.getConnections().stream()
+                        .map(conn -> StarryNightConnectionDto.builder()
+                                .connectionId(conn.getId())
+                                .startStarId(conn.getStart().getId())
+                                .endStarId(conn.getEnd().getId())
+                                .build())
+                        .collect(Collectors.toList())
+                        : Collections.emptyList())
+
+                .build();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/service/MyPageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/service/MyPageService.java
@@ -1,0 +1,280 @@
+package com.example.starlet_be.domains.mypage.service;
+
+import com.example.starlet_be.S3.dto.PublishedObject;
+import com.example.starlet_be.S3.service.S3StorageService;
+import com.example.starlet_be.domains.constellation.dto.StarryNightConstellationDto;
+import com.example.starlet_be.domains.constellation.entity.Constellation;
+import com.example.starlet_be.domains.constellation.repository.ConstellationRepository;
+import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.diary.entity.Emotion;
+import com.example.starlet_be.domains.diary.repository.DiaryRepository;
+import com.example.starlet_be.domains.mypage.dto.*;
+import com.example.starlet_be.domains.mypage.level.LevelPolicy;
+import com.example.starlet_be.domains.mypage.mapper.ConstellationMapper;
+import com.example.starlet_be.domains.star.repository.StarRepository;
+import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.domains.user.repository.UserRepository;
+import com.example.starlet_be.exception.CustomException;
+import com.example.starlet_be.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MyPageService {
+
+    private final UserRepository userRepository;
+    private final DiaryRepository diaryRepository;
+    private final ConstellationRepository constellationRepository;
+    private final StarRepository starRepository;
+    private final ConstellationMapper constellationMapper;
+    private final S3StorageService s3StorageService;
+
+    /**
+     * 마이페이지 요약 정보 조회
+     * <p>
+     * 사용자 ID를 기반으로 프로필, 레벨, 대표 별자리,
+     * 연간 별자리 통계 및 월별 감정 통계 데이터를 반환
+     * <br>
+     * <code>year</code>나 <code>month</code>가 null인 경우, 현재 날짜를 기준으로 조회
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @param year 조회할 연도 (null일 경우 현재 연도)
+     * @param month 조회할 달 (null일 경우 현재 달)
+     * @return MyPageSummaryResDto 마이페이지 요약 정보 DTO
+     *
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+
+    @Transactional(readOnly = true)
+    public MyPageSummaryResDto getSummary(Long userId, Integer year, Integer month) {
+        LocalDate now = LocalDate.now();
+        int y = (year == null ? now.getYear() : year);
+        int m = (month == null ? now.getMonthValue() : month);
+
+        UserSummaryResDto profile = getUserSummary(userId);
+
+        LevelResDto level = getLevel(userId);
+
+        StarryNightConstellationDto rep = getRepresentativeConstellation(userId);
+
+        List<MonthlyCountResDto> monthlyCount = getMonthlyCount(userId, y);
+
+        List<EmotionCountResDto> emotionCount = getEmotionCount(userId, y, m);
+
+        return MyPageSummaryResDto.of(profile, level, rep, monthlyCount, emotionCount);
+    }
+
+    /**
+     * 사용자 요약 정보 조회
+     * <p>
+     * 사용자 식별자로 DB에서 {@link User} 엔티티를 조회하고,
+     * 해당 사용자가 보유한 전체 별 개수와 별자리 개수를 반환
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @return UserSummaryResDto 사용자 닉네임, 총 별 개수, 총 별자리 개수를 포함한 DTO
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public UserSummaryResDto getUserSummary(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        long totalStars = starRepository.countByUser(user);
+        long totalConstellations = constellationRepository.countByUser(user);
+
+        return UserSummaryResDto.of(user, totalStars, totalConstellations);
+    }
+
+    /**
+     * 사용자 레벨 정보 조회
+     * <p>
+     * 사용자 ID를 기반으로 {@link User} 엔티티를 조회하고,
+     * 보유한 총 별 개수를 기준으로 {@link LevelPolicy}를 통해 레벨 정보를 계산
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @return LevelResDto 사용자 레벨 및 점수 정보 DTO
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public LevelResDto getLevel(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        Long totalStars = starRepository.countByUser(user);
+
+        return LevelPolicy.resolve(totalStars);
+    }
+
+    /**
+     * 대표 별자리 조회
+     * <p>
+     * 사용자 ID를 기반으로 {@link User} 엔티티를 조회하고,
+     * 해당 사용자의 대표 별자리(isRepresentative=true)를 반환
+     * 존재하지 않을 경우 {@code null}을 반환합니다.
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @return StarryNightConstellationDto 대표 별자리 정보 DTO (없을 경우 null)
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public StarryNightConstellationDto getRepresentativeConstellation(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        Optional<Constellation> rep = constellationRepository.findByUserAndIsRepresentative(user, true);
+
+        return rep.map(constellationMapper::toStarryNightDto).orElse(null);
+
+    }
+
+    /**
+     * 연간 월별 별자리 생성 통계 조회
+     * <p>
+     * 지정된 연도에 대해 사용자별 별자리 생성 수를 월 단위로 그룹화하여 반환
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @param year 조회할 연도
+     * @return List&lt;MonthlyCountResDto&gt; 월별 생성된 별자리 개수 리스트
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public List<MonthlyCountResDto> getMonthlyCount(Long userId, int year) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        LocalDate start = LocalDate.of(year, 1, 1);
+        LocalDate end = LocalDate.of(year, 12, 31);
+
+        List<Constellation> constellations =
+                constellationRepository.findAllByUserAndCreateAtBetween(user, start, end);
+
+        Map<Integer, Long> grouped = constellations.stream()
+                .filter(c -> c.getCreateAt() != null)
+                .collect(Collectors.groupingBy(
+                        c -> c.getCreateAt().getMonthValue(),
+                        Collectors.counting()
+                ));
+
+        return grouped.entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> new MonthlyCountResDto(e.getKey(), e.getValue()))
+                .toList();
+    }
+
+    /**
+     * 월별 감정 통계 조회
+     * <p>
+     * 지정된 연도와 월에 해당하는 사용자의 일기 데이터를 조회하여,
+     * 감정(Enum {@link Emotion})별 일기 개수를 집계
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @param year 조회할 연도
+     * @param month 조회할 달
+     * @return List&lt;EmotionCountResDto&gt; 감정별 일기 개수 리스트
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+    @Transactional(readOnly = true)
+    public List<EmotionCountResDto> getEmotionCount(Long userId, int year, int month) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        LocalDate start = LocalDate.of(year, month, 1);
+        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
+
+        List<Diary> diaries = diaryRepository.findAllByUserAndCreateAtBetween(user, start, end);
+
+        Map<Emotion, Long> grouped = diaries.stream()
+                .filter(d -> d.getEmotion() != null)
+                .collect(Collectors.groupingBy(Diary::getEmotion, Collectors.counting()));
+
+        return Arrays.stream(Emotion.values())
+                .map(e -> new EmotionCountResDto(e.name(), grouped.getOrDefault(e, 0L)))
+                .toList();
+    }
+
+
+    /**
+     * 프로필 사진 확정(수정)
+     * <p>
+     * 임시 저장된 S3 객체 키(<code>tempKey</code>)를 기반으로 프로필 사진을 발행하고,
+     * 사용자의 프로필 사진 URL을 업데이트
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @param tempKey S3 임시 객체 키
+     * @return ConfirmPhotoResDto 변경된 프로필 사진 URL DTO
+     * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
+     */
+    @Transactional
+    public ConfirmPhotoResDto confirmProfilePhoto(Long userId, String tempKey) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        PublishedObject po = s3StorageService.publishProfile(user.getId(), tempKey);
+        user.changeProfilePhotoUrl(po.getKey());
+        return ConfirmPhotoResDto.of(po.getUrl());
+    }
+
+    /**
+     * 닉네임 수정
+     * <p>
+     * 새로운 닉네임의 유효성을 검사하고, 중복 여부를 확인한 뒤
+     * 기존 사용자 닉네임과 다를 경우 변경
+     * </p>
+     *
+     * @param userId 사용자 ID
+     * @param newNickname 새 닉네임 (2~10자 사이)
+     * @return UpdateNicknameResDto 변경된 닉네임을 포함한 DTO
+     *
+     * @throws com.example.starlet_be.exception.CustomException
+     *         <ul>
+     *             <li>USER_NOT_FOUND - 존재하지 않는 사용자일 경우</li>
+     *             <li>INVALID_NICKNAME - 닉네임 길이가 유효하지 않은 경우</li>
+     *             <li>NICKNAME_CONFLICT - 이미 사용 중인 닉네임일 경우</li>
+     *         </ul>
+     */
+    @Transactional
+    public UpdateNicknameResDto updateNickname(Long userId, String newNickname) {
+        String nickname = newNickname == null ? "" : newNickname.trim();
+
+        if(nickname.length() < 2 || nickname.length() > 10) {
+            throw new CustomException(ErrorCode.INVALID_NICKNAME);
+        }
+
+        if(userRepository.existsByNicknameAndIdNot(nickname, userId)) {
+            throw new CustomException(ErrorCode.NICKNAME_CONFLICT);
+        }
+
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        if(!nickname.equals(user.getNickname())) {
+            user.changeNickname(nickname);
+        }
+
+        return UpdateNicknameResDto.of(user.getNickname());
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/service/MyPageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/service/MyPageService.java
@@ -54,7 +54,6 @@ public class MyPageService {
      *
      * @throws com.example.starlet_be.exception.CustomException USER_NOT_FOUND - 존재하지 않는 사용자일 경우 발생
      */
-
     @Transactional(readOnly = true)
     public MyPageSummaryResDto getSummary(Long userId, Integer year, Integer month) {
         LocalDate now = LocalDate.now();

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/repository/StarRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/repository/StarRepository.java
@@ -23,4 +23,6 @@ public interface StarRepository extends JpaRepository<Star, Long> {
     List<Star> findByUserAndDiary_CreateAtBetweenAndConstellationIsNull(User user, LocalDate startDate, LocalDate endDate);
 
     Integer countByConstellationAndColor(Constellation constellation, Color color);
+
+    Long countByUser(User user);
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/entity/User.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/entity/User.java
@@ -71,4 +71,6 @@ public class User{
     public void changeProfilePhotoUrl(String profilePhotoUrl) {
         this.profilePhotoUrl = profilePhotoUrl;
     }
+
+    public void changeNickname(String nickname) { this.nickname = nickname; }
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/repository/UserRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/repository/UserRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmailAddress(String email);
     boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndIdNot(String nickname, Long id);
 
     Optional<User> findByEmailAddress(String email);
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     NICKNAME_CONFLICT(409, "닉네임이 중복됩니다."),
     DUPLICATE_INFO_CONFLICT(409, "이미 사용중인 정보가 있습니다. 이메일과 닉네임 중복검사를 시행하세요."),
     USER_CREATE_FAILED(500, "유저 생성에 실패하였습니다."),
+    INVALID_NICKNAME(400, "사용할 수 없는 닉네임입니다."),
 
     // diary 관련
     DIARY_ALREADY_EXISTS(409, "해당 날짜에는 이미 감정 일기가 존재합니다."),


### PR DESCRIPTION
## PR 요약
- 마이페이지 도메인 주요 기능 구현 및 summary API 추가
  - 사용자 요약 정보, 레벨, 대표별자리, 월별 별자리/감정 통계, 프로필 수정(사진, 닉네임) 기능 구현
  - S3 Presigned URL 기반 프로필 사진 업로드 및 최종 확정 로직 추가
  - #51 의 presigned url 발급 기능과 연동

## 변경 내용
- 신규 기능 추가
  -  사용자 요약 정보 조회 API (`/api/v1/mypage/summary`)
  - 사용자 프로필 조회 API (`/api/v1/mypage/user`)
  - 사용자 레벨 조회 API (`/api/v1/mypage/level`)
  - 대표 별자리 조회 API (`/api/v1/mypage/representative`)
  - 연간 월별 별자리 수 통계 API (`/api/v1/mypage/year`)
  - 월별 감정 통계 API (`/api/v1/mypage/month`)
  - 프로필 사진 수정 API (`Presigned URL 발급 + 확정 저장 /photo/confirm`)
  - 닉네임 수정 API (`/api/v1/mypage/nickname`)

- 서비스 로직 구현
  - S3StorageService의 `publishProfile()`을 MyPageService에 통합하여 DB 반영이 가능하도록 수정


## 관련 이슈
- 연관 PR : #51
  - 마이페이지 수정 API는 **사진 수정(`/photo/confirm`)** 과 **닉네임 수정(`/nickname`)** 으로 분리하여 구현
  - 프로필 사진 url은 **key 기반 저장** 후, 응답 시 url 변환 구조로 확정
- `ETag` 기반 조건부 요청 및 캐싱 최적화 적용 필요 시 고려 예정
