### PR TITLE
밤하늘 별자리 생성, 조회 API 수정

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
@@ -32,7 +32,9 @@ public interface ConstellationApi {
                                             "userId": 1,
                                             "x": 0.1,
                                             "y": 0.2,
-                                            "belongDate": "2025-09-01"
+                                            "name": "북두칠성",
+                                            "createAt" : "2025-11-12",
+                                            "belongDate": "2025-09-01",
                                             "stars": [
                                                 {
                                                     "starId": 1,
@@ -77,6 +79,8 @@ public interface ConstellationApi {
                                             "userId": 1,
                                             "x": 0.6550693249242013,
                                             "y": 0.19746977186845616,
+                                            "name": "카시오페아자리",
+                                            "createAt" : "2025-11-10",
                                             "stars": [
                                                 {
                                                     "starId": 4,

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/dto/StarryNightConstellationDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/dto/StarryNightConstellationDto.java
@@ -16,6 +16,10 @@ public class StarryNightConstellationDto {
     private Double x;
     private Double y;
 
+    private String name;
+
+    private LocalDate createAt;
+
     private LocalDate belongDate;
 
 
@@ -30,13 +34,16 @@ public class StarryNightConstellationDto {
     @Builder
     public StarryNightConstellationDto(
             Long constellationId, Long userId,
-            Double x, Double y, LocalDate belongDate,
+            Double x, Double y, String name,
+            LocalDate createAt, LocalDate belongDate,
             List<StarryNightStarDto> stars,
             List<StarryNightConnectionDto> connections) {
         this.constellationId = constellationId;
         this.userId = userId;
         this.x = x;
         this.y = y;
+        this.name = name;
+        this.createAt = createAt;
         this.belongDate = belongDate;
         this.stars = stars;
         this.connections = connections;

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -61,6 +61,7 @@ public class ConstellationService {
      * 사용자가 존재하지 않으면 USER_NOT_FOUND
      * 별이 존재하지 않으면 STAR_NOT_FOUND
      * 선택한 별이 이미 별자리에 소속되어있으면 ALREADY_BELONG_TO_CONSTELLATION, 이 부분은 프론트 단에서 막아주긴 해야함
+     * 최초로 별자리를 등록한다면 즉시 대표별자리로 등록
      *
      * @param userDetails 토큰 기반 로그인 정보
      * @param dto 생성할 별자리 기본 정보 -> 별자리 이름, 설명, 별 리스트, 선 리스트
@@ -78,13 +79,19 @@ public class ConstellationService {
             throw new CustomException(ErrorCode.INAPPROPRIATE_CONTENT);
         }
 
+        // 최초 생성 별자리라면 그 별자리를 대표 별자리로
+        boolean isRepresentative = false;
+        if(constellationRepository.countByUser(user) == 0){
+            isRepresentative = true;
+        }
+
         // 별자리 생성
         Constellation constellation = Constellation.builder()
                 .user(user)
                 .name(dto.getName())
                 .description(dto.getDescription())
                 .createAt(LocalDate.now())
-                .isRepresentative(false)
+                .isRepresentative(isRepresentative)
                 .x(Math.random())
                 .y(Math.random())
                 .build();
@@ -384,7 +391,7 @@ public class ConstellationService {
      * 대표별자리 지정/변경 API
      *
      * Constellation의 boolean필드를 통해 대표별자리 변경을 시도합니다.
-     * 이미 대표별자리가 있을 경우 이전 별자리의 대표를 해제하고 새로운 별자리를 대표로 등록합니다.
+     * 이전 별자리의 대표를 해제하고 새로운 별자리를 대표로 등록합니다.
      *
      * @param id 새로 대표로 만들 별자리의 id 입니다.
      * @param userDetails 유저 정보 입니다.

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -197,6 +197,8 @@ public class ConstellationService {
                             .userId(con.getUser().getId())
                             .x(con.getX())
                             .y(con.getY())
+                            .name(con.getName())
+                            .createAt(con.getCreateAt())
                             .belongDate(con.getBelongDate())
                             .stars(starsInfo)
                             .connections(connectionsInfo)


### PR DESCRIPTION
## PR 요약
- 밤하늘 별자리 조회에 응답 필드를 추가하였습니다. (문서 변경 필요)
- 밤하늘 별자리 최초 생성 시 대표별자리로 등록하도록 변경하였습니다. (문서 변경 불필요)

---

## 변경 내용
- 추가된 필드
    - name : 별자리의 이름
    - createAt : 별자리의 생성일로 belongDate와는 다른 날짜임  
- 밤하늘 별자리 조회 Swagger 깨짐 수정
- 밤하늘 별자리 최초 생성(생성 전 시점에 별자리 0개)일때 생성한 별자리 즉시 대표별자리로 등록
