### PR TITLE
feat : 친구 기능 관련 API 구현 완료

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/S3/service/S3StorageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/S3/service/S3StorageService.java
@@ -82,4 +82,14 @@ public class S3StorageService {
 
         return PublishedObject.of(publicKey, url);
     }
+
+    public String convertToUrl(String key) {
+        if (key == null || key.isBlank()) {
+            return null;
+        }
+
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucket, region, key);
+    }
+
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/controller/FriendController.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/controller/FriendController.java
@@ -1,0 +1,117 @@
+package com.example.starlet_be.domains.friend.controller;
+
+import com.example.starlet_be.domains.friend.dto.*;
+import com.example.starlet_be.domains.friend.service.FriendService;
+import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+
+@RestController
+@RequestMapping("/api/v1/friends")
+@RequiredArgsConstructor
+public class FriendController {
+
+    private final UserRepository userRepository;
+    private final FriendService friendService;
+
+    //사용자 조회
+    @GetMapping("/search")
+    public ResponseEntity<FriendSearchResDto> searchFriend(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestParam String searchNickname
+
+    ) {
+        Long userId = resolveUserId(principal);
+        FriendSearchResDto body = friendService.searchFriend(userId, searchNickname);
+        return ResponseEntity.ok(body);
+    }
+
+    //친구 신청
+    @PostMapping("/request")
+    public ResponseEntity<?> requestFriend(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestBody FriendReqDto dto
+    ) {
+        Long userId = resolveUserId(principal);
+        friendService.requestFriend(userId, dto.getReceiverNickname());
+        return ResponseEntity.ok(
+                Map.of("message", "친구 요청을 보냈습니다."));
+    }
+
+    //친구 수락
+    @PostMapping("/accept")
+    public ResponseEntity<?> acceptFriend(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestBody FriendAcceptReqDto dto
+    ) {
+        Long userId = resolveUserId(principal);
+        friendService.acceptFriend(userId, dto.getFriendId());
+
+        return ResponseEntity.ok(
+                Map.of("message", "친구 요청을 수락했습니다.")
+        );
+    }
+
+    //친구 거절
+    @DeleteMapping("/reject")
+    public ResponseEntity<?> rejectFriend(
+            @AuthenticationPrincipal UserDetails principal,
+            @RequestBody FriendRejectReqDto dto ) {
+        Long userId = resolveUserId(principal);
+        friendService.rejectFriend(userId, dto.getFriendId());
+
+        return ResponseEntity.ok(
+                Map.of("message", "친구 요청을 거절했습니다.")
+        );
+    }
+
+    //친구 목록
+    @GetMapping("/list")
+    public ResponseEntity<List<FriendListItemResDto>> getMyFriends(
+            @AuthenticationPrincipal UserDetails principal
+    ) {
+        Long userId = resolveUserId(principal);
+        List<FriendListItemResDto> body = friendService.getMyFriends(userId);
+        return ResponseEntity.ok(body);
+    }
+
+    //친구 요청 목록
+    @GetMapping("/requests")
+    public ResponseEntity<List<FriendReqItemResDto>> getMyFriendRequest(
+            @AuthenticationPrincipal UserDetails principal
+    ) {
+        Long userId = resolveUserId(principal);
+        List<FriendReqItemResDto> body = friendService.getMyFriendRequests(userId);
+        return ResponseEntity.ok(body);
+    }
+
+    //친구 삭제
+    @DeleteMapping("/{friendId}")
+    public ResponseEntity<?> deleteFriend(
+            @AuthenticationPrincipal UserDetails principal,
+            @PathVariable Long friendId
+    ) {
+        Long userId = resolveUserId(principal);
+        friendService.deleteFriend(userId, friendId);
+
+        return ResponseEntity.ok(
+                Map.of("message", "친구를 삭제했습니다.")
+        );
+    }
+
+    private Long resolveUserId(UserDetails principal) {
+        String email = principal.getUsername();
+        return userRepository.findByEmailAddress(email)
+                .map(User::getId)
+                .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다: " + email));
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendAcceptReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendAcceptReqDto.java
@@ -1,0 +1,8 @@
+package com.example.starlet_be.domains.friend.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FriendAcceptReqDto {
+    private Long friendId;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendListItemResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendListItemResDto.java
@@ -1,0 +1,41 @@
+package com.example.starlet_be.domains.friend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendListItemResDto {
+
+    private Long id;
+
+    private Long userId;
+    private String nickname;
+    private String profileUrl;
+
+    private Long totalStars;
+    private Long totalConstellations;
+
+    private String level;
+
+    public static FriendListItemResDto of(
+            Long id,
+            Long userId,
+            String nickname,
+            String profileUrl,
+            Long totalStars,
+            Long totalConstellations,
+            String level
+    ) {
+        return FriendListItemResDto.builder()
+                .id(id)
+                .userId(userId)
+                .nickname(nickname)
+                .profileUrl(profileUrl)
+                .totalStars(totalStars)
+                .totalConstellations(totalConstellations)
+                .level(level)
+                .build();
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendRejectReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendRejectReqDto.java
@@ -1,0 +1,8 @@
+package com.example.starlet_be.domains.friend.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FriendRejectReqDto {
+    private Long friendId;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendReqDto.java
@@ -1,0 +1,8 @@
+package com.example.starlet_be.domains.friend.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FriendReqDto {
+    private String receiverNickname;
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendReqItemResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendReqItemResDto.java
@@ -1,0 +1,34 @@
+package com.example.starlet_be.domains.friend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendReqItemResDto {
+
+    private Long id;
+
+    private String nickname;
+    private String profileUrl;
+
+    private Long remainingSeconds;
+
+    private String dDayLabel;
+
+    public static FriendReqItemResDto of(
+            Long id,
+            String nickname,
+            String profileUrl,
+            Long remainingSeconds,
+            String dDayLabel
+    ) {
+        return FriendReqItemResDto.builder()
+                .id(id)
+                .nickname(nickname)
+                .profileUrl(profileUrl)
+                .remainingSeconds(remainingSeconds)
+                .dDayLabel(dDayLabel)
+                .build();
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendSearchResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/dto/FriendSearchResDto.java
@@ -1,0 +1,32 @@
+package com.example.starlet_be.domains.friend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class FriendSearchResDto {
+    private String nickname;
+    private String profileUrl;
+
+    private String status;
+
+    private Long remainingSeconds;
+
+    public static FriendSearchResDto of(
+            String nickname,
+            String profileUrl,
+            String status,
+            Long remainingSeconds
+    ) {
+        return FriendSearchResDto.builder()
+                .nickname(nickname)
+                .profileUrl(profileUrl)
+                .status(status)
+                .remainingSeconds(remainingSeconds)
+                .build();
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/entity/Friend.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/entity/Friend.java
@@ -1,0 +1,76 @@
+package com.example.starlet_be.domains.friend.entity;
+
+import com.example.starlet_be.domains.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "friend")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Friend {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "friend_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "requester", nullable = false)
+    private User requester;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver", nullable = false)
+    private User receiver;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    FriendStatus status;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+
+
+    public static Friend createPending(User requester, User receiver, LocalDateTime expiredAt) {
+        Friend friend = new Friend();
+        friend.requester = requester;
+        friend.receiver = receiver;
+        friend.status = FriendStatus.PENDING;
+        friend.createdAt = LocalDateTime.now();
+        friend.updatedAt = null;
+        friend.expiredAt = expiredAt;
+        return friend;
+    }
+
+    //친구 요청 수락
+    public void accept() {
+        this.status = FriendStatus.ACCEPTED;
+        this.updatedAt = LocalDateTime.now();
+        this.expiredAt = null;
+    }
+
+    //유효 여부
+    public boolean isPendingAndNotExpired() {
+        return this.status == FriendStatus.PENDING
+                && this.expiredAt != null
+                && this.expiredAt.isAfter(LocalDateTime.now());
+    }
+
+    //남은 유효시간
+    public Long getRemainingSeconds() {
+        if (expiredAt == null) return null;
+        LocalDateTime now = LocalDateTime.now();
+        if (!expiredAt.isAfter(now)) return null;
+        return java.time.Duration.between(now, expiredAt).getSeconds();
+    }
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/entity/FriendStatus.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/entity/FriendStatus.java
@@ -1,0 +1,7 @@
+package com.example.starlet_be.domains.friend.entity;
+
+public enum FriendStatus {
+    PENDING,
+    ACCEPTED,
+    NONE
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/repository/FriendRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/repository/FriendRepository.java
@@ -1,0 +1,38 @@
+package com.example.starlet_be.domains.friend.repository;
+
+import com.example.starlet_be.domains.friend.entity.Friend;
+import com.example.starlet_be.domains.friend.entity.FriendStatus;
+import com.example.starlet_be.domains.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+    Optional<Friend> findTop1ByRequesterAndReceiverOrderByCreatedAtDesc(
+            User requester,
+            User receiver
+    );
+
+    default Optional<Friend> findLatestBetween(User user1, User user2) {
+        Optional<Friend> req1 = findTop1ByRequesterAndReceiverOrderByCreatedAtDesc(user1, user2);
+        Optional<Friend> req2 = findTop1ByRequesterAndReceiverOrderByCreatedAtDesc(user2, user1);
+
+        if (req1.isEmpty()) return req2;
+        if (req2.isEmpty()) return req1;
+
+        return req1.get().getCreatedAt().isAfter(req2.get().getCreatedAt()) ? req1 : req2;
+    }
+
+    List<Friend> findAllByReceiverAndStatusOrderByCreatedAtDesc(
+            User receiver,
+            FriendStatus status
+    );
+
+    List<Friend> findAllByStatusAndRequesterOrStatusAndReceiver(
+            FriendStatus status1, User requester,
+            FriendStatus status2, User receiver
+    );
+}
+

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/service/FriendEmailService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/service/FriendEmailService.java
@@ -1,0 +1,149 @@
+package com.example.starlet_be.domains.friend.service;
+
+import com.example.starlet_be.domains.friend.entity.Friend;
+import com.example.starlet_be.domains.user.entity.User;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class FriendEmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${app.frontend.mail-url}")
+    private String baseUrl;
+
+    /**
+     * 친구 요청 메일을 수신자에게 전송
+     *
+     * @param requester 친구 요청을 보낸 사용자
+     * @param receiver  친구 요청을 받는 사용자
+     * @param request   생성된 친구 요청 엔티티
+     */
+    @Transactional
+    public void sendFriendRequestMail(User requester, User receiver, Friend request) {
+
+        //프론트 친구요청 페이지로 이동. 지금은 그냥 starlet 홈 링크 걸어두기
+        String link = baseUrl;
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper =
+                    new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(receiver.getEmail().getAddress());
+            helper.setSubject("[STARLET] 친구요청이 도착했습니다.");
+
+            String html = buildFriendRequestHtml(requester, link);
+            helper.setText(html, true);
+
+            mailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new RuntimeException("친구 요청 메일 전송 실패", e);
+        }
+    }
+
+    /**
+     * 친구 요청이 수락 -> 요청자에게 수락 알림 메일을 전송
+     *
+     * @param requester 친구 요청을 보낸 사용자
+     * @param receiver  요청을 수락한 사용자
+     */
+    @Transactional
+    public void sendFriendAcceptedMail(User requester, User receiver) {
+
+        //프론트 친구목록 페이지로 이동. 지금은 그냥 starlet 홈 링크 걸어두기
+        String link = baseUrl;
+
+        try {
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper =
+                    new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setTo(requester.getEmail().getAddress());  // 신청을 보낸 사람에게 메일
+            helper.setSubject("[STARLET] 친구요청이 수락되었습니다.");
+
+            String html = buildFriendAcceptedHtml(receiver, link);
+            helper.setText(html, true);
+
+            mailSender.send(message);
+
+        } catch (MessagingException e) {
+            throw new RuntimeException("친구 수락 메일 전송 실패", e);
+        }
+    }
+
+    //친구 요청 메일 이미지
+    private String buildFriendRequestHtml(User requester, String link) {
+        return """
+                <div style="font-family:Arial, sans-serif; padding:24px; background:#1B2735; color:white; border-radius:6px;">
+                           \s
+                            <h2 style="margin:0 0 12px 0; font-weight:700; font-size:24px;">STARLET</h2>
+                           \s
+                            <p style="margin:8px 0 5px 0; font-size:16px; line-height:1.5;">
+                                <b>%s</b> 님이 친구 요청을 보냈습니다.
+                            </p>
+                
+                            <p style="margin:0 0 18px 0; font-size:14px; color:#D0D0D0;">
+                                아래 버튼을 눌러 Starlet에서 친구 요청을 확인해보세요.
+                            </p>
+                
+                            <a href="%s" target="_blank"
+                               style="
+                                    display:inline-block;
+                                    padding:10px 10px;
+                                    background:#54C65B;
+                                    color:white;
+                                    font-size:14px;
+                                    border-radius:6px;
+                                    text-decoration:none;
+                                    font-weight:600;">
+                                친구 요청 보러 가기
+                            </a>
+                
+                        </div>
+            """.formatted(requester.getNickname(), link);
+    }
+
+    //친구 수락 메일 이미지
+    private String buildFriendAcceptedHtml(User receiver, String link) {
+        return """
+                <div style="font-family:Arial, sans-serif; padding:24px; background:#1B2735; color:white; border-radius:6px;">
+                
+                            <h2 style="margin:0 0 12px 0; font-weight:700; font-size:24px;">STARLET</h2>
+                
+                            <p style="margin:8px 0 5px 0; font-size:16px; line-height:1.5;">
+                                <b>%s</b> 님이 친구 요청을\s
+                                <span style="color:#54C65B; font-weight:700;">수락</span>했습니다.
+                            </p>
+                            
+                            <p style="margin:0 0 18px 0; font-size:14px; color:#D0D0D0;">
+                                아래 버튼을 눌러 Starlet에서 친구 목록을 확인해보세요.
+                            </p>
+                
+                            <a href="#" target="_blank"
+                               style="
+                                    display:inline-block;
+                                    padding:10px 10px;
+                                    background:#54C65B;
+                                    color:white;
+                                    font-size:14px;
+                                    border-radius:6px;
+                                    text-decoration:none;
+                                    font-weight:600;">
+                                친구 목록 보러 가기
+                            </a>
+                
+                        </div>
+                """.formatted(receiver.getNickname(), link);
+    }
+}
+

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/service/FriendService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/service/FriendService.java
@@ -1,0 +1,366 @@
+package com.example.starlet_be.domains.friend.service;
+
+import com.example.starlet_be.S3.service.S3StorageService;
+import com.example.starlet_be.domains.constellation.repository.ConstellationRepository;
+import com.example.starlet_be.domains.friend.dto.FriendListItemResDto;
+import com.example.starlet_be.domains.friend.dto.FriendReqItemResDto;
+import com.example.starlet_be.domains.friend.dto.FriendSearchResDto;
+import com.example.starlet_be.domains.friend.entity.Friend;
+import com.example.starlet_be.domains.friend.entity.FriendStatus;
+import com.example.starlet_be.domains.friend.repository.FriendRepository;
+import com.example.starlet_be.domains.mypage.dto.LevelResDto;
+import com.example.starlet_be.domains.mypage.level.LevelPolicy;
+import com.example.starlet_be.domains.star.repository.StarRepository;
+import com.example.starlet_be.domains.user.entity.User;
+import com.example.starlet_be.domains.user.repository.UserRepository;
+import com.example.starlet_be.exception.CustomException;
+import com.example.starlet_be.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+
+    private final UserRepository userRepository;
+    private final FriendRepository friendRepository;
+    private final FriendEmailService friendEmailService;
+    private final S3StorageService s3StorageService;
+
+    private final StarRepository starRepository;
+    private final ConstellationRepository constellationRepository;
+
+    /**
+     * 닉네임을 기준으로 사용자를 검색하고,
+     * 나와의 친구 관계 상태(NONE / PENDING / ACCEPTED)를 함께 반환
+     *
+     * @param userId   검색을 수행하는 사용자 ID
+     * @param nickname 검색할 대상 사용자의 닉네임
+     * @return 대상 유저 정보 및 친구 상태가 포함된 응답 DTO
+     * @throws CustomException USER_NOT_FOUND, CANNOT_SEARCH_SELF
+     */
+    @Transactional(readOnly = true)
+    public FriendSearchResDto searchFriend(Long userId, String nickname) {
+        User me = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        User target = userRepository.findByNickname(nickname).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        if(me.getId().equals(target.getId())) {
+            throw new CustomException(ErrorCode.CANNOT_SEARCH_SELF);
+        }
+
+        var latest = friendRepository.findLatestBetween(me, target);
+
+        String profileUrl = s3StorageService.convertToUrl(target.getProfilePhotoUrl());
+
+        //관계 없음
+        if(latest.isEmpty()) {
+            return FriendSearchResDto.of(
+                    target.getNickname(),
+                    profileUrl,
+                    "NONE",
+                    null
+            );
+        }
+
+        Friend f = latest.get();
+
+        //이미 친구 상태
+        if(f.getStatus() == FriendStatus.ACCEPTED) {
+            return FriendSearchResDto.of(
+                    target.getNickname(),
+                    profileUrl,
+                    "ACCEPTED",
+                    null
+            );
+        }
+
+        //PENDING상태 + 유효시간
+        if (f.isPendingAndNotExpired()) {
+            return FriendSearchResDto.of(
+                    target.getNickname(),
+                    profileUrl,
+                    "PENDING",
+                    f.getRemainingSeconds()
+            );
+        }
+
+        //PENDING 유효 만료 후 NONE
+        return FriendSearchResDto.of(
+                target.getNickname(),
+                profileUrl,
+                "NONE",
+                null
+        );
+    }
+
+    /**
+     * 친구 요청
+     * 이미 친구인 경우 예외
+     * 대기 중(PENDING)이며 아직 만료되지 않은 요청이 있으면 예외
+     * 요청 유효기간은 3일로 설정함
+     *
+     * @param requesterId      친구 요청을 보내는 사용자 ID
+     * @param receiverNickname 친구 요청을 받을 사용자의 닉네임
+     * @throws CustomException USER_NOT_FOUND, CANNOT_REQUEST_SELF,
+     *                         FRIEND_ALREADY_EXIST, FRIEND_REQUEST_ALREADY_PENDING
+     */
+    @Transactional
+    public void requestFriend(Long requesterId, String receiverNickname) {
+        User requester = userRepository.findById(requesterId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        User receiver = userRepository.findByNickname(receiverNickname).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        if (requester.getId().equals(receiver.getId())) {
+            throw new CustomException(ErrorCode.CANNOT_REQUEST_SELF);
+        }
+
+        Optional<Friend> latestOpt = friendRepository.findLatestBetween(requester, receiver);
+
+        if(latestOpt.isPresent()) {
+            Friend latest = latestOpt.get();
+
+            //이미 친구
+            if (latest.getStatus() == FriendStatus.ACCEPTED) {
+                throw new CustomException(ErrorCode.FRIEND_ALREADY_EXIST);
+            }
+
+            //유효시간 만료 전
+            if (latest.isPendingAndNotExpired()) {
+                throw new CustomException(ErrorCode.FRIEND_REQUEST_ALREADY_PENDING);
+            }
+        }
+
+        //유효기간 : 3일
+        LocalDateTime expiredAt = LocalDateTime.now().plusDays(3);
+        Friend newRequest = Friend.createPending(requester, receiver, expiredAt);
+        friendRepository.save(newRequest);
+
+        friendEmailService.sendFriendRequestMail(requester, receiver, newRequest);
+    }
+
+    /**
+     * 친구 요청 수락
+     *
+     * 해당 요청의 수신자와 현재 사용자 일치 여부 검증
+     * PENDING 상태 여부 검증
+     * 요청의 유효기간(pending + not expired) 검증
+     *
+     * @param receiverId 친구 요청을 수락하는 사용자 ID
+     * @param friendId   수락할 Friend 엔티티 ID
+     * @throws CustomException USER_NOT_FOUND, FRIEND_REQUEST_NOT_FOUND,
+     *                         FORBIDDEN, FRIEND_REQUEST_EXPIRED
+     */
+    @Transactional
+    public void acceptFriend(Long receiverId, Long friendId) {
+        User receiver = userRepository.findById(receiverId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        Friend request = friendRepository.findById(friendId).orElseThrow(
+                () -> new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND)
+        );
+
+        //본인 확인
+        if (!request.getReceiver().getId().equals(receiver.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        //PENDING 상태가 아닐 경우
+        if (request.getStatus() != FriendStatus.PENDING) {
+            throw new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND);
+        }
+
+        //유효기간 지남
+        if (!request.isPendingAndNotExpired()) {
+            throw new CustomException(ErrorCode.FRIEND_REQUEST_EXPIRED);
+        }
+
+        request.accept();
+
+        friendEmailService.sendFriendAcceptedMail(request.getRequester(), receiver);
+    }
+
+    /**
+     * 친구 요청 거절(삭제)
+     *
+     * @param receiverId 친구 요청을 거절하는 사용자 ID
+     * @param friendId   거절할 Friend 엔티티 ID
+     * @throws CustomException USER_NOT_FOUND, FRIEND_REQUEST_NOT_FOUND,
+     *                         FORBIDDEN, FRIEND_REQUEST_EXPIRED
+     */
+    @Transactional
+    public void rejectFriend(Long receiverId, Long friendId) {
+        User receiver = userRepository.findById(receiverId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        Friend request = friendRepository.findById(friendId).orElseThrow(
+                () -> new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND)
+        );
+
+        if(!request.getReceiver().getId().equals(receiver.getId())) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if(request.getStatus() != FriendStatus.PENDING) {
+            throw new CustomException(ErrorCode.FRIEND_REQUEST_NOT_FOUND);
+        }
+
+        if(!request.isPendingAndNotExpired()) {
+            throw new CustomException(ErrorCode.FRIEND_REQUEST_EXPIRED);
+        }
+
+        friendRepository.delete(request);
+    }
+
+    /**
+     * 받은 친구 요청 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return 친구 요청 목록 응답 DTO 리스트
+     * @throws CustomException USER_NOT_FOUND
+     */
+    @Transactional(readOnly = true)
+    public List<FriendReqItemResDto> getMyFriendRequests(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        List<Friend> requests = friendRepository
+                .findAllByReceiverAndStatusOrderByCreatedAtDesc(user, FriendStatus.PENDING);
+
+        LocalDateTime now = LocalDateTime.now();
+
+        return requests.stream()
+                .filter(Friend::isPendingAndNotExpired)
+                .map(f -> {
+                    Long remainingSeconds = f.getRemainingSeconds();
+                    String dDayLabel = toDDayLabel(now, f.getExpiredAt());
+
+                    String profileUrl = s3StorageService
+                            .convertToUrl(f.getRequester().getProfilePhotoUrl());
+
+                    return FriendReqItemResDto.of(
+                            f.getId(),
+                            f.getRequester().getNickname(),
+                            profileUrl,
+                            remainingSeconds,
+                            dDayLabel
+                    );
+                })
+                .toList();
+    }
+
+    /**
+     * 친구(ACCEPTED) 목록 조회
+     * 각 친구별로 보유 별/별자리 수와 레벨 정보를 함께 계산해서 내려줌
+     *
+     * @param userId 현재 로그인한 사용자 ID
+     * @return 친구 목록 응답 DTO 리스트
+     * @throws CustomException USER_NOT_FOUND
+     */
+    @Transactional(readOnly = true)
+    public List<FriendListItemResDto> getMyFriends(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        List<Friend> relations = friendRepository.findAllByStatusAndRequesterOrStatusAndReceiver(FriendStatus.ACCEPTED, user, FriendStatus.ACCEPTED, user);
+
+        return relations.stream()
+                .map(f -> {
+                    User friend = f.getRequester().getId().equals(userId)
+                            ? f.getReceiver() : f.getRequester();
+
+                    long totalStars = starRepository.countByUser(friend);
+                    long totalConstellations = constellationRepository.countByUser(friend);
+
+                    LevelResDto levelBody = LevelPolicy.resolve(totalStars);
+                    String level = levelBody.getName();
+
+                    String profileUrl = s3StorageService.convertToUrl(friend.getProfilePhotoUrl());
+
+                    return FriendListItemResDto.of(
+                            f.getId(),
+                            friend.getId(),
+                            friend.getNickname(),
+                            profileUrl,
+                            totalStars,
+                            totalConstellations,
+                            level
+                    );
+                })
+                .toList();
+    }
+
+    /**
+     * 친구 관계 삭제
+     *
+     * 요청자가 해당 친구 관계의 참여자인지 검증
+     * 현재 상태가 ACCEPTED 인 경우에만 삭제 허용
+     *
+     * @param userId   사용자 ID
+     * @param friendId 삭제할 Friend 엔티티 ID
+     * @throws CustomException USER_NOT_FOUND, FRIEND_NOT_FOUND, FORBIDDEN
+     */
+    @Transactional
+    public void deleteFriend(Long userId, Long friendId) {
+        User user = userRepository.findById(userId).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        Friend relation = friendRepository.findById(friendId).orElseThrow(
+                () -> new CustomException(ErrorCode.FRIEND_NOT_FOUND)
+        );
+
+        boolean isParticipant = relation.getRequester().getId().equals(user.getId()) || relation.getReceiver().getId().equals(user.getId());
+
+        if(!isParticipant) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        if(relation.getStatus() != FriendStatus.ACCEPTED) {
+            throw new CustomException(ErrorCode.FRIEND_NOT_FOUND);
+        }
+
+        friendRepository.delete(relation);
+    }
+
+
+
+    //[친구요청목록] 남은 날짜 계산
+    private String toDDayLabel(LocalDateTime now, LocalDateTime expiredAt) {
+        if(expiredAt == null) return null;
+
+        LocalDate today = now.toLocalDate();
+        LocalDate target = expiredAt.toLocalDate();
+
+        long days = ChronoUnit.DAYS.between(today, target);
+
+        if (days > 0) {
+            return "D-" + days;
+        } else if (days == 0) {
+            return "D-DAY";
+        } else {
+            return "EXPIRED";
+        }
+    }
+
+
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/repository/UserRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/repository/UserRepository.java
@@ -12,5 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
     boolean existsByNicknameAndIdNot(String nickname, Long id);
 
+    Optional<User> findByNickname(String nickname);
     Optional<User> findByEmailAddress(String email);
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
@@ -51,6 +51,16 @@ public enum ErrorCode {
     INAPPROPRIATE_CONTENT(400, "입력 내용에 부적절한 내용이 포함되었습니다."),
     OPENAI_SERVER_ERROR(500, "외부 서버(OpenAI) 오류입니다."),
 
+    //친구 관련
+    FRIEND_ALREADY_EXIST(409, "이미 친구 관계입니다."),
+    FRIEND_REQUEST_ALREADY_PENDING(400, "이미 처리 중인 친구 요청이 있습니다."),
+    FRIEND_REQUEST_NOT_FOUND(404, "유효한 친구 요청을 찾을 수 없습니다."),
+    FRIEND_NOT_FOUND(404, "친구 관계를 찾을 수 없습니다."),
+    FRIEND_REQUEST_EXPIRED(400, "친구 요청 유효 시간이 만료되었습니다."),
+    CANNOT_REQUEST_SELF(400, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+    CANNOT_SEARCH_SELF(400, "자기 자신은 검색할 수 없습니다."),
+    FORBIDDEN(403, "권한이 없습니다."),
+
 
     // 기타 관련
     INTERNAL_SERVER_ERROR(500, "내부 서버 오류입니다.");

--- a/Starlet_BE/src/main/resources/application.yml
+++ b/Starlet_BE/src/main/resources/application.yml
@@ -44,6 +44,7 @@ jwt:
 app:
   frontend:
     base-url: ${APP_FRONTEND_BASE_URL}
+    friend-url : ${APP_FRONTEND_MAIL_URL}
 
 
 s3:


### PR DESCRIPTION
## PR 요약
- 친구 기능 구현 완료
- 사용자 검색, 친구 요청/수락/거절, 친구 목록, 요청 목록, 친구 삭제 기능 추가
- 이메일 알림(요청, 수락 시) 발송 기능 포함

---

## 변경 내용
- 신규 기능 추가
   - 사용자 조회 (닉네임 검색) `/api/v1/friends/search`
   - 친구 요청 `/api/v1/friends/request`
   - 친구 수락 `/api/v1/friends/accept`
   - 친구 거절 `/api/v1/friends/reject`
   - 친구 삭제 `/api/v1/friends/{friendId}`
   - 친구 요청 목록 조회 `/api/v1/friends/requests`
   - 친구 목록 조회 `/api/v1/friends`

- 서비스 로직
  - FriendService
     친구 요청 생성 유효기간 3일로 설정
  - FriendEmailService 구현
     친구 요청/수락 시 이메일 html 템플릿 발송
  - S3StorageService
     key → url 변환용 메서드 추가


---

## 관련 이슈
- 현재 이메일 템플릿 내 링크는 임시로 서비스 홈 주소로 연결했습니다. 추후에 프론트 쪽 라우팅 확정되면 친구 요청 목록 페이지, 친구 목록 페이지로 직접 이동할 수 있도록 링크 주소 변경할 예정입니다!
