### PR TITLE
Security(JWT) 관련 리펙토링

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     NOT_VERIFY_USER(400, "이메일 미인증 / 비밀번호 재설정 중인 유저입니다."),
     VERIFY_TYPE_NOT_MATCHED(400, "인증 상태 타입이 일치하지 않습니다."),
     VERIFY_NOT_FOUND(404, "인증 정보를 찾을 수 없습니다."),
+    JWT_TOKEN_PARSING_ERROR(500, "JWT 필터링 오류가 발생하였습니다."),
 
 
     // 이메일 관련

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/CustomUserDetailService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/CustomUserDetailService.java
@@ -3,6 +3,8 @@ package com.example.starlet_be.security;
 import com.example.starlet_be.domains.user.entity.User;
 import com.example.starlet_be.domains.user.repository.UserRepository;
 import com.example.starlet_be.domains.verify.entity.VerifyType;
+import com.example.starlet_be.exception.CustomException;
+import com.example.starlet_be.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -16,11 +18,13 @@ public class CustomUserDetailService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        // 계정 정지 기능이 포함되어 불가피하게 DB조회 로직 추가
         User user = userRepository.findByEmailAddress(email).orElseThrow(
                 () -> new UsernameNotFoundException("이메일로 사용자를 찾을 수 없음"));
         if(user.getEmail().getVerify().getType() != VerifyType.VERIFY)
-            throw new IllegalArgumentException("이메일 인증 혹은 비밀번호 재설정이 필요합니다.");
+            throw new CustomException(ErrorCode.NOT_VERIFY_USER);
 
+        // 이때 반환하는 User는 시큐리티에 있는 User임
         return org.springframework.security.core.userdetails.User.builder()
                 .username(user.getEmail().getAddress())
                 .password(user.getPassword())

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtAuthenticationFilter.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtAuthenticationFilter.java
@@ -1,11 +1,14 @@
 package com.example.starlet_be.security;
 
+import com.example.starlet_be.exception.CustomAuthenticationEntryPoint;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -19,6 +22,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final CustomUserDetailService customUserDetailService;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 
     @Override
@@ -26,16 +30,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         String token = jwtUtil.resolveToken(request);
 
-        if(token != null && jwtUtil.validateToken(token)) {
-            String email = jwtUtil.getEmailFromToken(token);
-            UserDetails userDetails = customUserDetailService.loadUserByUsername(email);
+        if (token != null) {
+            try {
+                String email = jwtUtil.getEmailFromToken(token);
+                UserDetails userDetails = customUserDetailService.loadUserByUsername(email);
 
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (JwtException e) {
+                customAuthenticationEntryPoint.commence(request, response, new AuthenticationException(e.getMessage(), e) {});
+                return;
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtAuthenticationFilter.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtAuthenticationFilter.java
@@ -1,6 +1,7 @@
 package com.example.starlet_be.security;
 
 import com.example.starlet_be.exception.CustomAuthenticationEntryPoint;
+import com.example.starlet_be.exception.ErrorCode;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -8,7 +9,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -42,9 +42,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            } catch (JwtException e) {
-                customAuthenticationEntryPoint.commence(request, response, new AuthenticationException(e.getMessage(), e) {});
-                return;
+            } catch (JwtException | IllegalArgumentException e) {
+                request.setAttribute("exception", ErrorCode.JWT_TOKEN_PARSING_ERROR);
             }
         }
         filterChain.doFilter(request, response);

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtUtil.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtUtil.java
@@ -35,72 +35,23 @@ public class JwtUtil {
     }
 
     // 토큰 발급 종합
-//    private String generateToken(String email, long validTime) {
-//        return Jwts.builder()
-//                .setSubject(email)
-//                .setIssuedAt(new Date())
-//                .setExpiration(new Date(System.currentTimeMillis() + validTime))
-//                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
-//                .compact();
-//    }
-
     private String generateToken(String email, long validTime) {
         return Jwts.builder()
                 .subject(email)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + validTime))
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()), SignatureAlgorithm.HS256)
+//                .signWith(Keys.hmacShaKeyFor(secretKey.getEncoded()), SignatureAlgorithm.HS256)
+                .signWith(secretKey, Jwts.SIG.HS256)
                 .compact();
     }
 
-//    public String getEmailFromToken(String token){
-//        return Jwts.parserBuilder()
-//                .setSigningKey(secretKey.getBytes())
-//                .build()
-//                .parseClaimsJws(token)
-//                .getBody()
-//                .getSubject();
-//    }
-//
-//    public boolean validateToken(String token){
-//        try{
-//            Jwts.parserBuilder()
-//                    .setSigningKey(secretKey.getBytes())
-//                    .build()
-//                    .parseClaimsJws(token);
-//
-//            return true;
-//        }
-//        catch(JwtException | IllegalArgumentException e){
-//            return false;
-//        }
-//    }
-
-    private Key getSigningKey() {
-        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
-        return Keys.hmacShaKeyFor(keyBytes);
-    }
-
     public String getEmailFromToken(String token) {
-        // Jwts.parser()가 JwtParserBuilder를 반환합니다
-        Jws<Claims> jws = Jwts.parser()
-                .verifyWith((SecretKey) getSigningKey())   // 서명 검증 키 설정
-                .build()                       // JwtParser 생성
-                .parseClaimsJws(token);        // JWS 파싱 & 검증
-
-        return jws.getBody().getSubject();
-    }
-
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parser()
-                    .verifyWith((SecretKey) getSigningKey())
-                    .build()
-                    .parseClaimsJws(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
     }
 
     public String resolveToken(HttpServletRequest request) {
@@ -111,7 +62,6 @@ public class JwtUtil {
         return null;
     }
 
-    // 제대로 작동되는지는 테스트 필요
     public String extractRefreshTokenFromCookie(HttpServletRequest request) {
         if (request.getCookies() != null) {
             for (Cookie cookie : request.getCookies()) {

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtUtil.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/JwtUtil.java
@@ -1,7 +1,6 @@
 package com.example.starlet_be.security;
 
-import io.jsonwebtoken.*;
-import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -10,17 +9,21 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.util.Date;
 
 @Component
 public class JwtUtil {
 
-    @Value("${jwt.secret-key}")
-    private String secretKey;
+//    @Value("${jwt.secret-key}")
+    private final SecretKey secretKey;
 
     private final long accessValid = 1000L * 60 * 60; // 1시간
     private final long refreshValid = 1000L * 60 * 60 * 24 * 7; // 7일
+
+    public JwtUtil(@Value("${jwt.secret-key}") String secretKey) {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
 
     // 1. Access 토큰 발급
     public String createAccessToken(String email) {

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/SecurityConfig.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/SecurityConfig.java
@@ -41,6 +41,8 @@ public class SecurityConfig {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
                 .sessionManagement(sess ->
                         sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )

--- a/Starlet_BE/src/main/java/com/example/starlet_be/security/SecurityConfig.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/security/SecurityConfig.java
@@ -6,8 +6,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -23,7 +21,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-    private final CustomUserDetailService customUserDetailService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
@@ -37,14 +34,6 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
-    }
-
-    @Bean
-    public AuthenticationProvider authenticationProvider() {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(customUserDetailService);
-        provider.setPasswordEncoder(passwordEncoder());
-        return provider;
     }
 
     @Bean


### PR DESCRIPTION
## PR 요약
- Security 패키지 아래 클래스들에 대하여 리펙토링 작업을 진행하였습니다.

---

## 변경 내용
- JWT 관련 클래스 코드 리펙토링
    - JWT 0.12.6과 맞지 않는 코드 제거 및 변경
    - JWT 시크릿키 메소드 발급방법에서 생성자 발급 방식으로 변경
    - securityFilterChain 기본설정 비활성화 누락 코드 추가
    - JwtAutenticationFilter 클래스에 예외처리 위임(예외 던지지는 않고 저장만)
- Security 패키지 클래스, 커스텀 예외처리로 변경

---

## 관련 이슈
- 로컬에서 테스트했을땐 큰 문제 없었고 액세스 토큰까지 잘 발급되었습니다. 혹시 병합 후 오류가 발생하면 문의 바랍니다.
- 조금 찾아보니 JWT 토큰을 헤더로만 주는게 정석인거같은데 저희는 헤더, 바디 모두 반환하고 있습니다. 보안상 헤더에만 반환하는게 맞으니 다음회의때 상의해보고 헤더에만 담도록 변경 예정입니다.
