### PR TITLE
별자리 아카이브 페이지 조회 API 추가

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -334,6 +335,118 @@ public interface ConstellationApi {
                     }))
     })
     ResponseEntity<?> getArchiveList(@AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(
+            summary = "별자리 아카이브 페이지 조회",
+            description = """
+                    사용자가 생성한 별자리를 페이지 단위로 가져옵니다.
+                    쿼리 스트링으로 뒤에 페이지 번호(0번부터 시작하는거 고려)와 가져올 데이터 수를 작성해주시면 됩니다.
+                    예시) http://localhost:8080/api/v1/constellation/archive/paging?page=0&size=4
+                    
+                    아래 나타난 pageable 입력 JSON 형태는 무시해주세요.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "별자리 아카이브 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    [
+                                        {
+                                            "constellationId": 1,
+                                            "name": "카시오페이아자리",
+                                            "description": "카시오페아 자리 입니다.",
+                                            "date": "2025-10-03",
+                                            "isRepresentative": false,
+                                            "stars": [
+                                                {
+                                                    "starId": 1,
+                                                    "x": -0.15,
+                                                    "y": 0.0,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 2,
+                                                    "x": -0.05,
+                                                    "y": 0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 3,
+                                                    "x": 0.05,
+                                                    "y": -0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 4,
+                                                    "x": 0.15,
+                                                    "y": 0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 5,
+                                                    "x": 0.2,
+                                                    "y": 0.0,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 6,
+                                                    "x": -0.1,
+                                                    "y": 0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 7,
+                                                    "x": 0.1,
+                                                    "y": -0.1,
+                                                    "color": "YELLOW"
+                                                }
+                                            ],
+                                            "connections": [
+                                                {
+                                                    "startStarId": 1,
+                                                    "endStarId": 6
+                                                },
+                                                {
+                                                    "startStarId": 6,
+                                                    "endStarId": 2
+                                                },
+                                                {
+                                                    "startStarId": 2,
+                                                    "endStarId": 7
+                                                },
+                                                {
+                                                    "startStarId": 7,
+                                                    "endStarId": 4
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                    """)
+                    })
+            ),
+            @ApiResponse(responseCode = "401", description = "토큰 만료 혹은 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 401,
+                                        "message": "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 유저를 찾을 수 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getArchivePaging(
+            @AuthenticationPrincipal UserDetails userDetails,
+            Pageable pageable
+    );
 
     @Operation(summary = "별자리 아카이브 상세 조회", description = "특정 별자리의 상세 정보를 조회합니다.")
     @ApiResponses({

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/controller/ConstellationController.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/controller/ConstellationController.java
@@ -8,6 +8,7 @@ import com.example.starlet_be.domains.constellation.service.ConstellationService
 import com.example.starlet_be.domains.star.dto.request.StarsIdDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -75,6 +76,15 @@ public class ConstellationController implements ConstellationApi {
     @GetMapping("/archive")
     public ResponseEntity<?> getArchiveList(@AuthenticationPrincipal UserDetails userDetails){
         return ResponseEntity.ok().body(constellationService.getArchiveList(userDetails));
+    }
+
+    // 1.1. 별자리 아카이브 조회(별자리 페이징 조회)
+    @GetMapping("/archive/paging")
+    public ResponseEntity<?> getArchivePaging(
+            @AuthenticationPrincipal UserDetails userDetails,
+            Pageable pageable
+    ){
+        return ResponseEntity.ok().body(constellationService.getArchivePaging(userDetails, pageable));
     }
 
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
@@ -2,6 +2,8 @@ package com.example.starlet_be.domains.constellation.repository;
 
 import com.example.starlet_be.domains.constellation.entity.Constellation;
 import com.example.starlet_be.domains.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -11,6 +13,8 @@ import java.util.Optional;
 public interface ConstellationRepository extends JpaRepository<Constellation, Long> {
     List<Constellation> findByUserAndBelongDateBetween(User user, LocalDate startDate, LocalDate endDate);
     List<Constellation> findByUser(User user);
+
+    Page<Constellation> findByUser(User user, Pageable pageable);
 
     Optional<Constellation> findByUserAndIsRepresentative(User user, boolean isRepresentative);
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -4,22 +4,22 @@ import com.example.starlet_be.domains.connection.dto.response.ConnectionDto;
 import com.example.starlet_be.domains.connection.dto.response.StarryNightConnectionDto;
 import com.example.starlet_be.domains.connection.entity.Connection;
 import com.example.starlet_be.domains.connection.repository.ConnectionRepository;
+import com.example.starlet_be.domains.constellation.dto.request.ConstellationPositionDto;
+import com.example.starlet_be.domains.constellation.dto.request.CreateConstellationDto;
+import com.example.starlet_be.domains.constellation.dto.request.UpdateConstellationDto;
 import com.example.starlet_be.domains.constellation.dto.response.ArchiveDetailDto;
 import com.example.starlet_be.domains.constellation.dto.response.ArchiveDto;
 import com.example.starlet_be.domains.constellation.dto.response.ConstellationNameSuggestDto;
-import com.example.starlet_be.domains.constellation.dto.request.ConstellationPositionDto;
-import com.example.starlet_be.domains.constellation.dto.request.CreateConstellationDto;
 import com.example.starlet_be.domains.constellation.dto.response.StarryNightConstellationDto;
-import com.example.starlet_be.domains.constellation.dto.request.UpdateConstellationDto;
 import com.example.starlet_be.domains.constellation.entity.Constellation;
 import com.example.starlet_be.domains.constellation.repository.ConstellationRepository;
 import com.example.starlet_be.domains.diary.entity.Color;
 import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.star.dto.request.StarPositionDto;
+import com.example.starlet_be.domains.star.dto.request.StarsIdDto;
 import com.example.starlet_be.domains.star.dto.response.StarArchiveDetailDto;
 import com.example.starlet_be.domains.star.dto.response.StarArchiveDto;
-import com.example.starlet_be.domains.star.dto.request.StarPositionDto;
 import com.example.starlet_be.domains.star.dto.response.StarryNightStarDto;
-import com.example.starlet_be.domains.star.dto.request.StarsIdDto;
 import com.example.starlet_be.domains.star.entity.Star;
 import com.example.starlet_be.domains.star.repository.StarRepository;
 import com.example.starlet_be.domains.user.entity.User;
@@ -29,6 +29,8 @@ import com.example.starlet_be.exception.ErrorCode;
 import com.example.starlet_be.openai.service.ModerationService;
 import com.example.starlet_be.openai.service.OpenAIService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -298,6 +300,67 @@ public class ConstellationService {
                             .isRepresentative(con.isRepresentative())
                             .stars(starArchiveList)
                             .connections(connectionList)
+                    .build());
+        }
+
+        return archiveList;
+    }
+
+    /**
+     * 별자리 아카이브 페이징 조회
+     *
+     * 사용자가 만든 별자리를 모두 조회
+     *
+     * @param userDetails 사용자 로그인 정보
+     * @return 별자리 아카이브 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<ArchiveDto> getArchivePaging(
+            UserDetails userDetails,
+            Pageable pageable
+    ){
+
+        // 1. 사용자 조회
+        User user = userRepository.findByEmailAddress(userDetails.getUsername()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        // 2. 사용자의 별자리 모두 들고오기
+        Page<Constellation> constellations = constellationRepository.findByUser(user, pageable);
+
+        List<ArchiveDto> archiveList = new ArrayList<>();
+
+        for(Constellation con : constellations){
+            List<Star> stars = starRepository.findByConstellation(con);
+            List<StarArchiveDto> starArchiveList = new ArrayList<>();
+
+            for(Star star : stars){
+                starArchiveList.add(StarArchiveDto.builder()
+                        .starId(star.getId())
+                        .x(star.getX())
+                        .y(star.getY())
+                        .color(star.getColor().toString())
+                        .build());
+            }
+
+            List<Connection> connections = connectionRepository.findByConstellation(con);
+            List<ConnectionDto> connectionList = new ArrayList<>();
+
+            for(Connection connection : connections){
+                connectionList.add(ConnectionDto.builder()
+                        .startStarId(connection.getStart().getId())
+                        .endStarId(connection.getEnd().getId())
+                        .build());
+            }
+
+            archiveList.add(ArchiveDto.builder()
+                    .constellationId(con.getId())
+                    .name(con.getName())
+                    .description(con.getDescription())
+                    .date(con.getCreateAt())
+                    .isRepresentative(con.isRepresentative())
+                    .stars(starArchiveList)
+                    .connections(connectionList)
                     .build());
         }
 


### PR DESCRIPTION
## PR 요약
- 별자리 연관관계가 매우 복잡하여 조회 시 DB 과부하의 우려로 기존에 전체를 조회하던 API에서 아카이브 페이지 조회 API를 별도로 구현하였습니다.

---

## 변경 내용
- 별자리 아카이브 페이지 조회 API 구현
    - /api/v1/constellation/archive/paging?page=0&size=1 (사용예시)
- 구현한 부분에 대한 Swagger 작성

---

## 관련 이슈
- 혹시 별자리처럼 로딩 부하가 큰 엔티티가 존재하면 페이지 기반 조회를 구현하는것도 고려해보면 좋겠습니다.
