### PR TITLE
별자리 아카이브 페이지 조회 API 추가

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -334,6 +335,118 @@ public interface ConstellationApi {
                     }))
     })
     ResponseEntity<?> getArchiveList(@AuthenticationPrincipal UserDetails userDetails);
+
+    @Operation(
+            summary = "별자리 아카이브 페이지 조회",
+            description = """
+                    사용자가 생성한 별자리를 페이지 단위로 가져옵니다.
+                    쿼리 스트링으로 뒤에 페이지 번호(0번부터 시작하는거 고려)와 가져올 데이터 수를 작성해주시면 됩니다.
+                    예시) http://localhost:8080/api/v1/constellation/archive/paging?page=0&size=4
+                    
+                    아래 나타난 pageable 입력 JSON 형태는 무시해주세요.
+                    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "별자리 아카이브 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    [
+                                        {
+                                            "constellationId": 1,
+                                            "name": "카시오페이아자리",
+                                            "description": "카시오페아 자리 입니다.",
+                                            "date": "2025-10-03",
+                                            "isRepresentative": false,
+                                            "stars": [
+                                                {
+                                                    "starId": 1,
+                                                    "x": -0.15,
+                                                    "y": 0.0,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 2,
+                                                    "x": -0.05,
+                                                    "y": 0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 3,
+                                                    "x": 0.05,
+                                                    "y": -0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 4,
+                                                    "x": 0.15,
+                                                    "y": 0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 5,
+                                                    "x": 0.2,
+                                                    "y": 0.0,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 6,
+                                                    "x": -0.1,
+                                                    "y": 0.1,
+                                                    "color": "YELLOW"
+                                                },
+                                                {
+                                                    "starId": 7,
+                                                    "x": 0.1,
+                                                    "y": -0.1,
+                                                    "color": "YELLOW"
+                                                }
+                                            ],
+                                            "connections": [
+                                                {
+                                                    "startStarId": 1,
+                                                    "endStarId": 6
+                                                },
+                                                {
+                                                    "startStarId": 6,
+                                                    "endStarId": 2
+                                                },
+                                                {
+                                                    "startStarId": 2,
+                                                    "endStarId": 7
+                                                },
+                                                {
+                                                    "startStarId": 7,
+                                                    "endStarId": 4
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                    """)
+                    })
+            ),
+            @ApiResponse(responseCode = "401", description = "토큰 만료 혹은 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 401,
+                                        "message": "토큰이 없거나 만료되었습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "해당 유저를 찾을 수 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getArchivePaging(
+            @AuthenticationPrincipal UserDetails userDetails,
+            Pageable pageable
+    );
 
     @Operation(summary = "별자리 아카이브 상세 조회", description = "특정 별자리의 상세 정보를 조회합니다.")
     @ApiResponses({

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/api/ConstellationApi.java
@@ -341,86 +341,220 @@ public interface ConstellationApi {
             description = """
                     사용자가 생성한 별자리를 페이지 단위로 가져옵니다.
                     쿼리 스트링으로 뒤에 페이지 번호(0번부터 시작하는거 고려)와 가져올 데이터 수를 작성해주시면 됩니다.
+                    
                     예시) http://localhost:8080/api/v1/constellation/archive/paging?page=0&size=4
+                    
+                    - JSON 페이징 관련 핵심 반환값 설명
+                    
+                    totalElements: 전체 데이터 개수 (모든 페이지를 합친 총 데이터 수, 프론트엔드에서 페이지 번호 계산 시 필수)
+                    
+                    totalPages: 전체 페이지 개수 (totalElements / size 로 계산된 결과), 사이즈를 고정할거기에 바로 쓰셔도 됩니다.
+                    
+                    last: 현재 페이지가 마지막 페이지인지 여부 (true/false)
+                    
+                    first: 현재 페이지가 첫 번째 페이지인지 여부 (true/false)
+                    
+                    size: 한 페이지당 조회할 데이터 개수 (요청한 size 값)
+                    
+                    number: 현재 페이지 번호 (0부터 시작, ex: 0이 1페이지)
+                    
+                    numberOfElements: 현재 반환된 페이지에 실제로 들어있는 데이터 개수 (마지막 페이지 등에서 size보다 작을 수 있음)
+                    
+                    empty: 데이터가 비어있는지 여부 (content가 비었으면 true)
+                    
+                    그외 응답 필드들은 중요하지 않습니다.
+                    
                     
                     아래 나타난 pageable 입력 JSON 형태는 무시해주세요.
                     """
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "별자리 아카이브 조회 성공",
+            @ApiResponse(responseCode = "200", description = "별자리 아카이브 페이지 조회 성공",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
-                                    [
-                                        {
-                                            "constellationId": 1,
-                                            "name": "카시오페이아자리",
-                                            "description": "카시오페아 자리 입니다.",
-                                            "date": "2025-10-03",
-                                            "isRepresentative": false,
-                                            "stars": [
-                                                {
-                                                    "starId": 1,
-                                                    "x": -0.15,
-                                                    "y": 0.0,
-                                                    "color": "YELLOW"
-                                                },
-                                                {
-                                                    "starId": 2,
-                                                    "x": -0.05,
-                                                    "y": 0.1,
-                                                    "color": "YELLOW"
-                                                },
-                                                {
-                                                    "starId": 3,
-                                                    "x": 0.05,
-                                                    "y": -0.1,
-                                                    "color": "YELLOW"
-                                                },
-                                                {
-                                                    "starId": 4,
-                                                    "x": 0.15,
-                                                    "y": 0.1,
-                                                    "color": "YELLOW"
-                                                },
-                                                {
-                                                    "starId": 5,
-                                                    "x": 0.2,
-                                                    "y": 0.0,
-                                                    "color": "YELLOW"
-                                                },
-                                                {
-                                                    "starId": 6,
-                                                    "x": -0.1,
-                                                    "y": 0.1,
-                                                    "color": "YELLOW"
-                                                },
-                                                {
-                                                    "starId": 7,
-                                                    "x": 0.1,
-                                                    "y": -0.1,
-                                                    "color": "YELLOW"
-                                                }
-                                            ],
-                                            "connections": [
-                                                {
-                                                    "startStarId": 1,
-                                                    "endStarId": 6
-                                                },
-                                                {
-                                                    "startStarId": 6,
-                                                    "endStarId": 2
-                                                },
-                                                {
-                                                    "startStarId": 2,
-                                                    "endStarId": 7
-                                                },
-                                                {
-                                                    "startStarId": 7,
-                                                    "endStarId": 4
-                                                }
-                                            ]
-                                        }
-                                    ]
+                                    {
+                                         "content": [
+                                             {
+                                                 "constellationId": 2,
+                                                 "name": "북두칠성",
+                                                 "description": "국자 모양의 유명한 별자리입니다.",
+                                                 "date": "2025-10-31",
+                                                 "isRepresentative": false,
+                                                 "stars": [
+                                                     {
+                                                         "starId": 1,
+                                                         "x": 0.05,
+                                                         "y": 0.0,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 2,
+                                                         "x": 0.15,
+                                                         "y": 0.03,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 3,
+                                                         "x": 0.2,
+                                                         "y": -0.05,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 4,
+                                                         "x": 0.15,
+                                                         "y": -0.15,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 5,
+                                                         "x": 0.0,
+                                                         "y": -0.1,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 6,
+                                                         "x": -0.1,
+                                                         "y": -0.05,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 7,
+                                                         "x": -0.15,
+                                                         "y": 0.05,
+                                                         "color": "YELLOW"
+                                                     }
+                                                 ],
+                                                 "connections": [
+                                                     {
+                                                         "startStarId": 1,
+                                                         "endStarId": 2
+                                                     },
+                                                     {
+                                                         "startStarId": 2,
+                                                         "endStarId": 3
+                                                     },
+                                                     {
+                                                         "startStarId": 3,
+                                                         "endStarId": 4
+                                                     },
+                                                     {
+                                                         "startStarId": 4,
+                                                         "endStarId": 5
+                                                     },
+                                                     {
+                                                         "startStarId": 5,
+                                                         "endStarId": 6
+                                                     },
+                                                     {
+                                                         "startStarId": 6,
+                                                         "endStarId": 7
+                                                     }
+                                                 ]
+                                             },
+                                             {
+                                                 "constellationId": 3,
+                                                 "name": "북두칠성",
+                                                 "description": "국자 모양의 유명한 별자리입니다.",
+                                                 "date": "2025-10-31",
+                                                 "isRepresentative": true,
+                                                 "stars": [
+                                                     {
+                                                         "starId": 15,
+                                                         "x": 0.05,
+                                                         "y": 0.0,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 16,
+                                                         "x": 0.15,
+                                                         "y": 0.03,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 17,
+                                                         "x": 0.2,
+                                                         "y": -0.05,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 18,
+                                                         "x": 0.15,
+                                                         "y": -0.15,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 19,
+                                                         "x": 0.0,
+                                                         "y": -0.1,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 20,
+                                                         "x": -0.1,
+                                                         "y": -0.05,
+                                                         "color": "YELLOW"
+                                                     },
+                                                     {
+                                                         "starId": 21,
+                                                         "x": -0.15,
+                                                         "y": 0.05,
+                                                         "color": "YELLOW"
+                                                     }
+                                                 ],
+                                                 "connections": [
+                                                     {
+                                                         "startStarId": 15,
+                                                         "endStarId": 16
+                                                     },
+                                                     {
+                                                         "startStarId": 16,
+                                                         "endStarId": 17
+                                                     },
+                                                     {
+                                                         "startStarId": 17,
+                                                         "endStarId": 18
+                                                     },
+                                                     {
+                                                         "startStarId": 18,
+                                                         "endStarId": 19
+                                                     },
+                                                     {
+                                                         "startStarId": 19,
+                                                         "endStarId": 20
+                                                     },
+                                                     {
+                                                         "startStarId": 20,
+                                                         "endStarId": 21
+                                                     }
+                                                 ]
+                                             }
+                                         ],
+                                         "pageable": {
+                                             "pageNumber": 0,
+                                             "pageSize": 2,
+                                             "sort": {
+                                                 "empty": true,
+                                                 "sorted": false,
+                                                 "unsorted": true
+                                             },
+                                             "offset": 0,
+                                             "paged": true,
+                                             "unpaged": false
+                                         },
+                                         "totalElements": 2,
+                                         "totalPages": 1,
+                                         "last": true,
+                                         "size": 2,
+                                         "number": 0,
+                                         "sort": {
+                                             "empty": true,
+                                             "sorted": false,
+                                             "unsorted": true
+                                         },
+                                         "first": true,
+                                         "numberOfElements": 2,
+                                         "empty": false
+                                     }
                                     """)
                     })
             ),

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/controller/ConstellationController.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/controller/ConstellationController.java
@@ -8,6 +8,7 @@ import com.example.starlet_be.domains.constellation.service.ConstellationService
 import com.example.starlet_be.domains.star.dto.request.StarsIdDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -75,6 +76,15 @@ public class ConstellationController implements ConstellationApi {
     @GetMapping("/archive")
     public ResponseEntity<?> getArchiveList(@AuthenticationPrincipal UserDetails userDetails){
         return ResponseEntity.ok().body(constellationService.getArchiveList(userDetails));
+    }
+
+    // 1.1. 별자리 아카이브 조회(별자리 페이징 조회)
+    @GetMapping("/archive/paging")
+    public ResponseEntity<?> getArchivePaging(
+            @AuthenticationPrincipal UserDetails userDetails,
+            Pageable pageable
+    ){
+        return ResponseEntity.ok().body(constellationService.getArchivePaging(userDetails, pageable));
     }
 
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/repository/ConstellationRepository.java
@@ -2,6 +2,8 @@ package com.example.starlet_be.domains.constellation.repository;
 
 import com.example.starlet_be.domains.constellation.entity.Constellation;
 import com.example.starlet_be.domains.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
@@ -11,6 +13,8 @@ import java.util.Optional;
 public interface ConstellationRepository extends JpaRepository<Constellation, Long> {
     List<Constellation> findByUserAndBelongDateBetween(User user, LocalDate startDate, LocalDate endDate);
     List<Constellation> findByUser(User user);
+
+    Page<Constellation> findByUser(User user, Pageable pageable);
 
     Optional<Constellation> findByUserAndIsRepresentative(User user, boolean isRepresentative);
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -4,22 +4,22 @@ import com.example.starlet_be.domains.connection.dto.response.ConnectionDto;
 import com.example.starlet_be.domains.connection.dto.response.StarryNightConnectionDto;
 import com.example.starlet_be.domains.connection.entity.Connection;
 import com.example.starlet_be.domains.connection.repository.ConnectionRepository;
+import com.example.starlet_be.domains.constellation.dto.request.ConstellationPositionDto;
+import com.example.starlet_be.domains.constellation.dto.request.CreateConstellationDto;
+import com.example.starlet_be.domains.constellation.dto.request.UpdateConstellationDto;
 import com.example.starlet_be.domains.constellation.dto.response.ArchiveDetailDto;
 import com.example.starlet_be.domains.constellation.dto.response.ArchiveDto;
 import com.example.starlet_be.domains.constellation.dto.response.ConstellationNameSuggestDto;
-import com.example.starlet_be.domains.constellation.dto.request.ConstellationPositionDto;
-import com.example.starlet_be.domains.constellation.dto.request.CreateConstellationDto;
 import com.example.starlet_be.domains.constellation.dto.response.StarryNightConstellationDto;
-import com.example.starlet_be.domains.constellation.dto.request.UpdateConstellationDto;
 import com.example.starlet_be.domains.constellation.entity.Constellation;
 import com.example.starlet_be.domains.constellation.repository.ConstellationRepository;
 import com.example.starlet_be.domains.diary.entity.Color;
 import com.example.starlet_be.domains.diary.entity.Diary;
+import com.example.starlet_be.domains.star.dto.request.StarPositionDto;
+import com.example.starlet_be.domains.star.dto.request.StarsIdDto;
 import com.example.starlet_be.domains.star.dto.response.StarArchiveDetailDto;
 import com.example.starlet_be.domains.star.dto.response.StarArchiveDto;
-import com.example.starlet_be.domains.star.dto.request.StarPositionDto;
 import com.example.starlet_be.domains.star.dto.response.StarryNightStarDto;
-import com.example.starlet_be.domains.star.dto.request.StarsIdDto;
 import com.example.starlet_be.domains.star.entity.Star;
 import com.example.starlet_be.domains.star.repository.StarRepository;
 import com.example.starlet_be.domains.user.entity.User;
@@ -29,6 +29,8 @@ import com.example.starlet_be.exception.ErrorCode;
 import com.example.starlet_be.openai.service.ModerationService;
 import com.example.starlet_be.openai.service.OpenAIService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -298,6 +300,67 @@ public class ConstellationService {
                             .isRepresentative(con.isRepresentative())
                             .stars(starArchiveList)
                             .connections(connectionList)
+                    .build());
+        }
+
+        return archiveList;
+    }
+
+    /**
+     * 별자리 아카이브 페이징 조회
+     *
+     * 사용자가 만든 별자리를 모두 조회
+     *
+     * @param userDetails 사용자 로그인 정보
+     * @return 별자리 아카이브 DTO 리스트
+     */
+    @Transactional(readOnly = true)
+    public List<ArchiveDto> getArchivePaging(
+            UserDetails userDetails,
+            Pageable pageable
+    ){
+
+        // 1. 사용자 조회
+        User user = userRepository.findByEmailAddress(userDetails.getUsername()).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+
+        // 2. 사용자의 별자리 모두 들고오기
+        Page<Constellation> constellations = constellationRepository.findByUser(user, pageable);
+
+        List<ArchiveDto> archiveList = new ArrayList<>();
+
+        for(Constellation con : constellations){
+            List<Star> stars = starRepository.findByConstellation(con);
+            List<StarArchiveDto> starArchiveList = new ArrayList<>();
+
+            for(Star star : stars){
+                starArchiveList.add(StarArchiveDto.builder()
+                        .starId(star.getId())
+                        .x(star.getX())
+                        .y(star.getY())
+                        .color(star.getColor().toString())
+                        .build());
+            }
+
+            List<Connection> connections = connectionRepository.findByConstellation(con);
+            List<ConnectionDto> connectionList = new ArrayList<>();
+
+            for(Connection connection : connections){
+                connectionList.add(ConnectionDto.builder()
+                        .startStarId(connection.getStart().getId())
+                        .endStarId(connection.getEnd().getId())
+                        .build());
+            }
+
+            archiveList.add(ArchiveDto.builder()
+                    .constellationId(con.getId())
+                    .name(con.getName())
+                    .description(con.getDescription())
+                    .date(con.getCreateAt())
+                    .isRepresentative(con.isRepresentative())
+                    .stars(starArchiveList)
+                    .connections(connectionList)
                     .build());
         }
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -312,10 +312,11 @@ public class ConstellationService {
      * 사용자가 만든 별자리를 모두 조회
      *
      * @param userDetails 사용자 로그인 정보
+     * @param pageable 페이지 번호와 가져올 개수 지정
      * @return 별자리 아카이브 DTO 리스트
      */
     @Transactional(readOnly = true)
-    public List<ArchiveDto> getArchivePaging(
+    public Page<ArchiveDto> getArchivePaging(
             UserDetails userDetails,
             Pageable pageable
     ){
@@ -328,9 +329,8 @@ public class ConstellationService {
         // 2. 사용자의 별자리 모두 들고오기
         Page<Constellation> constellations = constellationRepository.findByUser(user, pageable);
 
-        List<ArchiveDto> archiveList = new ArrayList<>();
-
-        for(Constellation con : constellations){
+        // 3. map을 통한 별자리 아카이브 페이지 목록 반환
+        return constellations.map(con -> {
             List<Star> stars = starRepository.findByConstellation(con);
             List<StarArchiveDto> starArchiveList = new ArrayList<>();
 
@@ -353,7 +353,8 @@ public class ConstellationService {
                         .build());
             }
 
-            archiveList.add(ArchiveDto.builder()
+            // 함수 내부에서 결과를 리턴
+            return ArchiveDto.builder()
                     .constellationId(con.getId())
                     .name(con.getName())
                     .description(con.getDescription())
@@ -361,10 +362,8 @@ public class ConstellationService {
                     .isRepresentative(con.isRepresentative())
                     .stars(starArchiveList)
                     .connections(connectionList)
-                    .build());
-        }
-
-        return archiveList;
+                    .build();
+        });
     }
 
     /**


### PR DESCRIPTION
## PR 요약
- 별자리 연관관계가 매우 복잡하여 조회 시 DB 과부하의 우려로 기존에 전체를 조회하던 API에서 아카이브 페이지 조회 API를 별도로 구현하였습니다.

---

## 변경 내용
- 별자리 아카이브 페이지 조회 API 구현
    - /api/v1/constellation/archive/paging?page=0&size=1 (사용예시)
- 구현한 부분에 대한 Swagger 작성

---

## 관련 이슈
- 혹시 별자리처럼 로딩 부하가 큰 엔티티가 존재하면 페이지 기반 조회를 구현하는것도 고려해보면 좋겠습니다.
- 페이지 관련해서 JSON 반환 형태가 변경되었으니 확인 바랍니다.(프론트엔드)
    - 주의점 1 : 기존 별자리 정보들의 상위에 "content"라는 것이 추가됨
    - 주의점 2 : 페이지 관련 필드들이 많이 추가되었으니 Swagger 참고 바랍니다.
