### PR TITLE
닉네임 최대 글자 수 10->6자 변경

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/api/MyPageApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/api/MyPageApi.java
@@ -312,7 +312,7 @@ public interface MyPageApi {
             summary = "닉네임 수정",
             description = """
                     사용자의 닉네임을 수정합니다.
-                    - 2~10자 이내 닉네임만 허용
+                    - 2~6자 이내 닉네임만 허용
                     - 앞 뒤 공백 자동 제거
                     - 기존 닉네임과 동일하면 변경하지 않고 그대로 반환
                     - 중복, 부적절한 닉네임 불가
@@ -330,7 +330,7 @@ public interface MyPageApi {
             @ApiResponse(responseCode = "400", description = "닉네임 형식/길이 오류",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """
-                                    { "status": 400, "message": "닉네임은 2~10자 사이여야 합니다." }
+                                    { "status": 400, "message": "닉네임은 2~6자 사이여야 합니다." }
                                     """))),
             @ApiResponse(responseCode = "409", description = "닉네임 중복",
                     content = @Content(mediaType = "application/json",

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/request/UpdateNicknameReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/request/UpdateNicknameReqDto.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Getter
 public class UpdateNicknameReqDto {
     @NotBlank(message = "닉네임을 입력하세요.")
-    @Size(min = 2, max = 10, message = "닉네임은 2~10자여야 합니다.")
+    @Size(min = 2, max = 6, message = "닉네임은 2~6자여야 합니다.")
     private String nickname;
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/api/UserApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/api/UserApi.java
@@ -102,7 +102,7 @@ public interface UserApi {
                                     """),
                             @ExampleObject(name = "닉네임 길이 초과", value = """
                                     {
-                                        "nickname": "닉네임은 최소 2글자, 최대 10글자 까지 가능합니다."
+                                        "nickname": "닉네임은 최소 2글자, 최대 6글자 까지 가능합니다."
                                     }
                                     """),
                             @ExampleObject(name = "인증 되지 않은 계정", value = """

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/dto/request/SignUpDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/dto/request/SignUpDto.java
@@ -13,7 +13,7 @@ public class SignUpDto {
 
     @Schema(description = "사용자 닉네임", example = "우리 은하")
     @NotBlank(message = "닉네임은 필수 입력입니다.")
-    @Size(max = 10, min = 2, message = "닉네임은 최소 2글자, 최대 10글자 까지 가능합니다.")
+    @Size(max = 6, min = 2, message = "닉네임은 최소 2글자, 최대 6글자 까지 가능합니다.")
     private String nickname;
 
     @Schema(description = "비밀번호", example = "sl1234")


### PR DESCRIPTION
## PR 요약
- 요구사항 변경으로 인해 닉네임 최대 길이 수를 조절하였습니다.

---

## 관련 이슈
- 프론트엔드 분들은 SRS를 참고해서 제약조건을 통일 바랍니다.
