### PR TITLE
feat : [마이페이지] 응답값 수정, 기본 이미지 설정 관련 추가

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/S3/service/S3StorageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/S3/service/S3StorageService.java
@@ -17,6 +17,8 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class S3StorageService {
 
+    private static final String DEFAULT_PROFILE_KEY = "public/defaults/profileDefault.png";
+
     private final S3Presigner presigner;
     private final S3Client s3Client;
 
@@ -61,10 +63,20 @@ public class S3StorageService {
      */
     public PublishedObject publishProfile(Long userId, String tempKey) {
 
-        String allowedPrefix = "uploads/users/" + userId + "/";
-        if (tempKey == null || !tempKey.startsWith(allowedPrefix)) {
+        if (tempKey == null || tempKey.isBlank()) {
             throw new IllegalArgumentException("잘못된 tempKey입니다.");
         }
+
+        //기본 이미지
+        if(tempKey.equals("defaults")) {
+            String url = convertToUrl(DEFAULT_PROFILE_KEY);
+            return PublishedObject.of(DEFAULT_PROFILE_KEY, url);
+        }
+
+        String allowedPrefix = "uploads/users/" + userId + "/";
+            if(!tempKey.startsWith(allowedPrefix)) {
+                throw new IllegalArgumentException("잘못된 tempKey입니다.");
+            }
 
         String publicKey = "public/users/" + userId + "/profile.png";
 
@@ -76,7 +88,6 @@ public class S3StorageService {
                 .build();
 
         s3Client.copyObject(copyReq);
-
         String url = String.format("https://%s.s3.%s.amazonaws.com/%s",
                 bucket, region, publicKey);
 
@@ -85,7 +96,8 @@ public class S3StorageService {
 
     public String convertToUrl(String key) {
         if (key == null || key.isBlank()) {
-            return null;
+            return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                    bucket, region, DEFAULT_PROFILE_KEY);
         }
 
         return String.format("https://%s.s3.%s.amazonaws.com/%s",

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/repository/FriendRepository.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/repository/FriendRepository.java
@@ -5,6 +5,7 @@ import com.example.starlet_be.domains.friend.entity.FriendStatus;
 import com.example.starlet_be.domains.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -34,5 +35,16 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
             FriendStatus status1, User requester,
             FriendStatus status2, User receiver
     );
+
+    long countByRequesterIdAndStatus(Long requesterId, FriendStatus status);
+
+    long countByReceiverIdAndStatus(Long receiverId, FriendStatus status);
+
+    default long countAcceptedFriendsByUserId(Long userId) {
+        return countByRequesterIdAndStatus(userId, FriendStatus.ACCEPTED)
+                + countByReceiverIdAndStatus(userId, FriendStatus.ACCEPTED);
+    }
+
+    void deleteByStatusAndExpiredAtBefore(FriendStatus status, LocalDateTime now);
 }
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/service/FriendCleanupService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/friend/service/FriendCleanupService.java
@@ -1,0 +1,27 @@
+package com.example.starlet_be.domains.friend.service;
+
+import com.example.starlet_be.domains.friend.entity.FriendStatus;
+import com.example.starlet_be.domains.friend.repository.FriendRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class FriendCleanupService {
+
+    private final FriendRepository friendRepository;
+
+    // 매일 새벽 3시마다
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void deleteExpiredPendingFriends() {
+        friendRepository.deleteByStatusAndExpiredAtBefore(
+                FriendStatus.PENDING,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/api/MyPageApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/api/MyPageApi.java
@@ -41,6 +41,7 @@ public interface MyPageApi {
                                         "totalStars": 12,
                                         "totalConstellations": 3
                                         "profilePhotoUrl": "https://..."
+                                        "friendsCount": 10
                                       },
                                       "level": {
                                         "code": "STARLIGHT_EXPLORER",
@@ -275,17 +276,32 @@ public interface MyPageApi {
             description = """
                     Presigned URL 업로드 후, 임시 key(tempKey)를 전달하면
                     실제 프로필 경로로 발행하고, 최종 프로필 이미지 URL을 반환합니다.
+                    
+                    - 일반 사진 변경 : tempKey에 `uploads/users/{userId}/...` 형태의 임시 키 전달
+                    - 기본 이미지로 변경 : tempKey에 문자열 `defaults` 형태로 전달
                     """
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공",
                     content = @Content(mediaType = "application/json",
                             schema = @Schema(implementation = ConfirmPhotoResDto.class),
-                            examples = @ExampleObject(value = """
-                                    {
-                                      "profileUrl": "https://starlet-s3-bucket/profile/user-1.png"
-                                    }
-                                    """))),
+                            examples = {
+                                    @ExampleObject(
+                                            name = "사용자 업로드 이미지로 변경",
+                                            value = """
+                                                    {
+                                                        "profileUrl": "https://starlet-s3-bucket/profile/user-1.png"
+                                                    }
+                                                    """),
+                                    @ExampleObject(
+                                            name = "기본 이미지로 변경",
+                                            value = """
+                                                    {
+                                                       "profileUrl": "https://starlet-s3-bucket.s3.ap-northeast-2.amazonaws.com/public/defaults/profileDefault.png" 
+                                                    }
+                                                    """
+                                    )
+                            })),
             @ApiResponse(responseCode = "400", description = "요청 형식 오류",
                     content = @Content(mediaType = "application/json",
                             examples = @ExampleObject(value = """

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/request/ConfirmPhotoReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/request/ConfirmPhotoReqDto.java
@@ -1,5 +1,6 @@
 package com.example.starlet_be.domains.mypage.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -8,5 +9,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class ConfirmPhotoReqDto {
     @NotBlank
+    @Schema(
+            description = "임시 S3 객체 key. 기본 이미지로 변경하려면 'defaults' 전달",
+            example = "uploads/users/1/profile1.png"
+    )
     private String tempKey;
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/request/UpdateNicknameReqDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/request/UpdateNicknameReqDto.java
@@ -1,5 +1,6 @@
 package com.example.starlet_be.domains.mypage.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -8,5 +9,6 @@ import lombok.Getter;
 public class UpdateNicknameReqDto {
     @NotBlank(message = "닉네임을 입력하세요.")
     @Size(min = 2, max = 6, message = "닉네임은 2~6자여야 합니다.")
+    @Schema(example = "새닉네임")
     private String nickname;
 }

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/response/UserSummaryResDto.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/dto/response/UserSummaryResDto.java
@@ -23,12 +23,16 @@ public class UserSummaryResDto{
     @Schema(example = "https://...")
     private String profilePhotoUrl;
 
-    public static UserSummaryResDto of(User user, long totalStars, long totalConstellations, String profilePhotoUrl) {
+    @Schema(example = "10")
+    private long friendsCount;
+
+    public static UserSummaryResDto of(User user, long totalStars, long totalConstellations, String profilePhotoUrl, long friendsCount) {
         return UserSummaryResDto.builder()
                 .nickname(user.getNickname())
                 .totalStars((int) totalStars)
                 .totalConstellations((int) totalConstellations)
                 .profilePhotoUrl(profilePhotoUrl)
+                .friendsCount(friendsCount)
                 .build();
     }
 

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/service/MyPageService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/mypage/service/MyPageService.java
@@ -8,6 +8,7 @@ import com.example.starlet_be.domains.constellation.repository.ConstellationRepo
 import com.example.starlet_be.domains.diary.entity.Diary;
 import com.example.starlet_be.domains.diary.entity.Emotion;
 import com.example.starlet_be.domains.diary.repository.DiaryRepository;
+import com.example.starlet_be.domains.friend.repository.FriendRepository;
 import com.example.starlet_be.domains.mypage.dto.response.*;
 import com.example.starlet_be.domains.mypage.level.LevelPolicy;
 import com.example.starlet_be.domains.mypage.mapper.ConstellationMapper;
@@ -40,6 +41,7 @@ public class MyPageService {
     private final ConstellationMapper constellationMapper;
     private final S3StorageService s3StorageService;
     private final ModerationService moderationService;
+    private final FriendRepository friendRepository;
 
     /**
      * 마이페이지 요약 정보 조회
@@ -96,9 +98,10 @@ public class MyPageService {
         long totalStars = starRepository.countByUser(user);
         long totalConstellations = constellationRepository.countByUser(user);
         String profilePhotoUrl = s3StorageService.convertToUrl(user.getProfilePhotoUrl());
+        long friendsCount = friendRepository.countAcceptedFriendsByUserId(userId);
 
 
-        return UserSummaryResDto.of(user, totalStars, totalConstellations, profilePhotoUrl);
+        return UserSummaryResDto.of(user, totalStars, totalConstellations, profilePhotoUrl, friendsCount);
     }
 
     /**


### PR DESCRIPTION
## PR 요약
- 친구 기능이 추가됨에 따라 마이페이지 응답값에 친구 수(`friendsCount) 추가
- 마이페이지 프로필 수정 시,  기본 이미지로 변경할 경우 S3의 default 이미지 경로를 db에 반영
- 친구 요청 유효기간이 지난 요청들을 clean 하는 스케줄러 추가

---

## 변경 내용
- 기능 개선

1.  마이페이지 응답에 친구 수 추가

       - 친구 기능이 추가되고, ui가 수정되어 마이페이지 응답값에 `friendsCount`를 추가했습니다.
   

2. 프로필 기본 이미지 처리

   - 마이페이지 프로필 수정에서, "기본 이미지로 변경" 시 s3에 저장되어있는 default 이미지를 db에 저장하도록 수정했습니다.
   - 사용자의 프로필 사진이 null인 경우에도 프로필 조회 시 기본 이미지를 반환하도록 보완했습니다.

- 신규 기능 추가
    - 기존 코드에서, expired된 친구 요청도 여전히 DB에 남아있는 오류를 발견하여 매일 새벽 3시에 일괄적으로 expired된 친구 요청을 clean하는 스케줄러를 구현했습니다.
    
- 문서 업데이트
   - 마이페이지에 추가된 응답값 반영
   - 기본 이미지 변경에 관한 description 추가
   - 닉네임 변경 dto에 스키마 정보 보완

---

## 관련 이슈
- s3 권한 설정을 기존 `"•••/public/users/*"` 에서 `"•••/public/*"` 로 완화시켰습니다. (기본 이미지가 public/defaults/... 에 저장되어 있음)
