### PR TITLE
회원탈퇴 오류 수정 : Friend Cascade 설정

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/entity/User.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/user/entity/User.java
@@ -3,6 +3,7 @@ package com.example.starlet_be.domains.user.entity;
 import com.example.starlet_be.domains.constellation.entity.Constellation;
 import com.example.starlet_be.domains.diary.entity.Diary;
 import com.example.starlet_be.domains.email.entity.Email;
+import com.example.starlet_be.domains.friend.entity.Friend;
 import com.example.starlet_be.domains.star.entity.Star;
 import com.example.starlet_be.domains.user.dto.response.UserResDto;
 import jakarta.persistence.CascadeType;
@@ -52,6 +53,12 @@ public class User{
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Constellation> constellations = new ArrayList<>();
+
+    @OneToMany(mappedBy = "requester", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Friend> sentFriendRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "receiver", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Friend> receivedFriendRequests = new ArrayList<>();
 
     @Builder public User(String nickname, String password, Email email, String profilePhotoUrl) {
         this.nickname = nickname;


### PR DESCRIPTION
## PR 요약
- 회원탈퇴 오류에 대한 외래키 제약조건 문제를 발견하여 Friend - User 엔티티 간의 Cascade설정을 변경하였습니다.

---

## 변경 내용
- User 엔티티에 Friend과 OneToMany 양방향 매핑 후 CascadeType.REMOVE 설정

---

## 관련 이슈
- 이 문제일꺼라 확신하고 현재 친구 설정이 되어있는 서버에서 바로 테스트하기위해 PR 합니다.