### PR TITLE
별/별자리 이동 조건 반대 오류 수정

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/constellation/service/ConstellationService.java
@@ -241,8 +241,8 @@ public class ConstellationService {
             throw new CustomException(ErrorCode.CONSTELLATION_POSITION_OUT_OF_SCOPE);
 
         // 별자리가 너무 밖으로 나가지 않게 조정, 나간다면 제자리로
-        Double changeX = (dto.getX() > 0.15 && dto.getX() < 0.85) ? constellation.getX() : dto.getX();
-        Double changeY = (dto.getY() > 0.15 && dto.getY() < 0.85) ? constellation.getY() : dto.getY();
+        Double changeX = (dto.getX() > 0.15 && dto.getX() < 0.85) ? dto.getX() : constellation.getX();
+        Double changeY = (dto.getY() > 0.15 && dto.getY() < 0.85) ? dto.getY() : constellation.getY();
 
         // 3. 위치 적용
         constellation.changePosition(changeX, changeY);

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/service/StarService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/star/service/StarService.java
@@ -130,8 +130,8 @@ public class StarService {
             throw new CustomException(ErrorCode.STAR_POSITION_OUT_OF_SCOPE);
 
         // 별이 너무 밖으로 나가지 않게 조정, 나간다면 제자리로
-        Double changeX = (dto.getX() > 0.05 && dto.getX() < 0.95) ? star.getX() : dto.getX();
-        Double changeY = (dto.getY() > 0.05 && dto.getY() < 0.95) ? star.getY() : dto.getY();
+        Double changeX = (dto.getX() > 0.05 && dto.getX() < 0.95) ? dto.getX() : star.getX();
+        Double changeY = (dto.getY() > 0.05 && dto.getY() < 0.95) ? dto.getY() : star.getY();
 
         // 3. 위치 적용
         star.changePosition(changeX, changeY);


### PR DESCRIPTION
## PR 요약
- 별/별자리가 이동범위를 초과할때 이동을 제한하는 조건이 반대인 오류를 수정하였습니다.
---

## 관련 이슈
- 죄송합니다
