### PR TITLE
feat : 당일만 일기 작성이 가능하도록 수정

### DIFF
--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/api/DiaryApi.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/api/DiaryApi.java
@@ -228,37 +228,6 @@ public interface DiaryApi {
             @RequestParam int month
     );
 
-    /* ====================================== */
-    @Operation(
-            summary = "(개발용) 감정 일기 삭제",
-            description = """
-            사용자가 지우고자 하는 감정 일기를 지울 수 있습니다.
-            """
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "삭제 성공",
-                    content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = DiaryResDto.class),
-                            examples = @ExampleObject(value = """
-                    {
-                    }
-                """))),
-            @ApiResponse(responseCode = "401", description = "액세스 토큰 미입력/만료",
-                    content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                    { "status": 401, "message": "토큰이 없거나 만료되었습니다." }
-                """))),
-            @ApiResponse(responseCode = "404", description = "해당 ID 일기 없음",
-                    content = @Content(mediaType = "application/json",
-                            examples = @ExampleObject(value = """
-                    { "status": 409, "message": "해당 날짜의 감정 일기를 찾을 수 없습니다." }
-                """)))
-    })
-    @DeleteMapping("/{diaryId}")
-    ResponseEntity<?> removeDiary(
-            @AuthenticationPrincipal UserDetails principal,
-            @PathVariable("diaryId") Long diaryId
-    );
 
     @Operation(summary = "한달 일기 분석", description = "한달의 일기 정보들을 종합하여 알려주는 API")
     @ApiResponses({

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/controller/DiaryController.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/controller/DiaryController.java
@@ -86,16 +86,6 @@ public class DiaryController implements DiaryApi {
                 .orElseThrow(() -> new IllegalStateException("존재하지 않는 사용자입니다: " + email));
     }
 
-    @DeleteMapping("/{diaryId}")
-    public ResponseEntity<Object> removeDiary(
-            @AuthenticationPrincipal UserDetails principal,
-            @PathVariable("diaryId") Long diaryId ) {
-        Long userId = resolveUserId(principal);
-
-        diaryService.delete(userId, diaryId);
-        return ResponseEntity.noContent().build();
-    }
-
     // 한달 일기 종합 분석요약, 파라미터로 연월 입력
     @GetMapping("/diary/summary")
     public ResponseEntity<?> getDiaryMonthSummary(

--- a/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/domains/diary/service/DiaryService.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -48,7 +49,7 @@ public class DiaryService {
     /**
      * 새로운 감정 일기를 생성한다.
      *
-     * date가 null이면 오늘 날짜로 기본 설정
+     * req로 받은 date가 오늘 날짜와 다르면 DIARY_NOT_CREATE 예외 발생
      * 동일 사용자/날짜의 일기가 이미 있으면 DiaryExceptions.AlreadyExists 예외 발생
      * 일기에 부적절한 표현이 심하게 존재하면 INAPPROPRIATE_CONTENT 예외 발생
      * 감정 일기 생성 후, star 생성
@@ -60,9 +61,14 @@ public class DiaryService {
      */
     @Transactional
     public DiaryResDto create(Long userId, DiaryCreateReqDto req) {
-        LocalDate date = (req.getDate() != null) ? req.getDate() : LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
-        if (diaryRepository.existsByUser_IdAndCreateAt(userId, date)) {
+        LocalDate requestDate = req.getDate();
+        if (requestDate != null && !requestDate.isEqual(today)) {
+            throw new CustomException(ErrorCode.DIARY_NOT_CREATE);
+        }
+
+        if (diaryRepository.existsByUser_IdAndCreateAt(userId, today)) {
             throw new CustomException(ErrorCode.DIARY_ALREADY_EXISTS);
         }
 
@@ -79,7 +85,7 @@ public class DiaryService {
                     .emotion(req.getEmotion())
                     .factors(safeFactors(req.getFactors()))
                     .content(req.getContent())
-                    .createAt(date)
+                    .createAt(today)
                     .build();
 
             diaryRepository.save(diary);
@@ -164,24 +170,25 @@ public class DiaryService {
                 .toList();
     }
 
-    /**
-     * (개발용) 일기 삭제
-     *
-     * @param userId 사용자 ID
-     * @param diaryId 삭제할 diary ID
-     */
-    public void delete(Long userId, Long diaryId) {
-        Diary diary = diaryRepository.findByIdAndUser_Id(diaryId, userId)
-                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND)); // 타인/없음 은닉
-
-        diaryRepository.delete(diary);
-    }
-
+//    /**
+//     * (개발용) 일기 삭제
+//     *
+//     * @param userId 사용자 ID
+//     * @param diaryId 삭제할 diary ID
+//     */
+//    public void delete(Long userId, Long diaryId) {
+//        Diary diary = diaryRepository.findByIdAndUser_Id(diaryId, userId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.DIARY_NOT_FOUND)); // 타인/없음 은닉
+//
+//        diaryRepository.delete(diary);
+//    }
+//
     private List<Factor> safeFactors(List<Factor> in) {
         return (in != null) ? new ArrayList<>(in) : new ArrayList<>();
     }
 
 
+    // 일기 요약 ai
     public DiarySummaryResDto getDiaryMonthSummary(UserDetails details, Integer year, Integer month) {
         if(month < 1 || month > 12) {
             throw new CustomException(ErrorCode.DIARY_INVALID_MONTH);

--- a/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
+++ b/Starlet_BE/src/main/java/com/example/starlet_be/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     DIARY_ALREADY_EXISTS(409, "해당 날짜에는 이미 감정 일기가 존재합니다."),
     DIARY_NOT_FOUND(404, "해당 날짜의 감정 일기를 찾을 수 없습니다."),
     DIARY_INVALID_MONTH(400, "month는 1~12 사이여야 합니다."),
+    DIARY_NOT_CREATE(400, "당일 일기만 작성할 수 있습니다."),
 
 
     // 별 관련


### PR DESCRIPTION
## PR 요약
- 개발 버전이었던 일기 작성 수준을, 제출 전 강화시켰습니다.
- 일기 삭제 api delete

---

## 변경 내용
- 수정내용
     - 일기는 당일 일기만 작성 가능하도록 수정했습니다.
     - 개발용 일기삭제 api 삭제했습니다.
- 문서
     - swagger에 있는 일기삭제 api delete
---

## 관련 이슈
- 마지막 pr이길 바라며...☘️
